### PR TITLE
Wrong HTTP header sent when requesting gzip

### DIFF
--- a/lib/httpi/request.rb
+++ b/lib/httpi/request.rb
@@ -46,7 +46,7 @@ module HTTPI
 
     # Adds a header information to accept gzipped content.
     def gzip
-      headers["Accept-encoding"] = "gzip,deflate"
+      headers["Accept-Encoding"] = "gzip,deflate"
     end
 
     attr_accessor :body, :open_timeout, :read_timeout, :auth_type

--- a/spec/httpi/request_spec.rb
+++ b/spec/httpi/request_spec.rb
@@ -61,9 +61,9 @@ describe HTTPI::Request do
   end
 
   describe "#gzip" do
-    it "should add the proper 'Accept-encoding' header" do
+    it "should add the proper 'Accept-Encoding' header" do
       request.gzip
-      request.headers["Accept-encoding"].should == "gzip,deflate"
+      request.headers["Accept-Encoding"].should == "gzip,deflate"
     end
   end
 


### PR DESCRIPTION
The correct spelling of "Accept-Encoding" capitalizes the "E", but `httpi` leaves it lowercase, as in "Accept-encoding".

Although HTTP headers are case-insensitive, this may cause problems with some clients that expect to see "Accept-Encoding" rather than the lowercase variant.
