### PR TITLE
Fixing body in the post and put methods of curb adapter

### DIFF
--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -28,7 +28,7 @@ module HTTPI
       # Executes an HTTP POST request.
       # @see HTTPI.post
       def post(request)
-        do_request(request) { |client, body| client.http_post body }
+        do_request(request) { |client| client.http_post request.body }
       end
 
       # Executes an HTTP HEAD request.
@@ -40,7 +40,7 @@ module HTTPI
       # Executes an HTTP PUT request.
       # @see HTTPI.put
       def put(request)
-        do_request(request) { |client, body| client.http_put body }
+        do_request(request) { |client| client.http_put request.body }
       end
 
       # Executes an HTTP DELETE request.

--- a/spec/httpi/adapter/curb_spec.rb
+++ b/spec/httpi/adapter/curb_spec.rb
@@ -41,6 +41,13 @@ describe HTTPI::Adapter::Curb do
     end
   end
 
+  describe "#post includes body of request" do
+    it "should send the body in the request" do
+      curb.expects(:http_post).with('xml=hi&name=123')
+      adapter.post(basic_request { |request| request.body = 'xml=hi&name=123' } )
+    end
+  end
+
   describe "#head" do
     before do
       curb.expects(:http_head)
@@ -64,6 +71,13 @@ describe HTTPI::Adapter::Curb do
 
     it "should return a valid HTTPI::Response" do
       adapter.put(basic_request).should match_response(:body => Fixture.xml)
+    end
+  end
+
+  describe "#put includes body of request" do
+    it "should send the body in the request" do
+      curb.expects(:http_put).with('xml=hi&name=123')
+      adapter.put(basic_request { |request| request.body = 'xml=hi&name=123' } )
     end
   end
 


### PR DESCRIPTION
Hi Daniel,

I've got one more fix on httpi. Somehow you were using a extra parameter at the block on post and put (body) that was not being used and would actually break get, delete and head methods if called on yield. The solution is pretty trivial, just use request.body as it is in scope. This time I was able to place a couple tests to make the point as I am using httpi alone now.

Hope it helps!
