### PR TITLE
Curb headers

### DIFF
--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -68,7 +68,7 @@ module HTTPI
         client.proxy_url = request.proxy.to_s if request.proxy
         client.timeout = request.read_timeout if request.read_timeout
         client.connect_timeout = request.open_timeout if request.open_timeout
-        client.headers = request.headers
+        client.headers = request.headers.to_hash
         client.verbose = false
       end
 


### PR DESCRIPTION
Curb support were broken by my inclusion of Rack::Utils::HeaderHash. This fixes it.
