### PR TITLE
Bug solved when no certificates are specified

### DIFF
--- a/lib/httpi/auth/ssl.rb
+++ b/lib/httpi/auth/ssl.rb
@@ -42,7 +42,7 @@ module HTTPI
 
       # Returns an <tt>OpenSSL::X509::Certificate</tt> for the +cert_file+.
       def cert
-        @cert ||= OpenSSL::X509::Certificate.new File.read(cert_file)
+        @cert ||= OpenSSL::X509::Certificate.new File.read(cert_file) if cert_file
       end
 
       # Sets the +OpenSSL+ certificate.
@@ -58,7 +58,7 @@ module HTTPI
 
       # Returns an <tt>OpenSSL::PKey::RSA</tt> for the +cert_key_file+.
       def cert_key
-        @cert_key ||= OpenSSL::PKey::RSA.new(File.read(cert_key_file), cert_key_password)
+        @cert_key ||= OpenSSL::PKey::RSA.new(File.read(cert_key_file), cert_key_password) if cert_key_file
       end
 
       # Sets the +OpenSSL+ certificate key.


### PR DESCRIPTION
Hi, 

I was getting this when trying to make a request specifying verify_mode = :none but not specifying any certificates
     can't convert nil into String
     # /usr/local/rvm/gems/ruby-1.8.7-p302/gems/httpi-0.7.5/lib/httpi/auth/ssl.rb:61:in `read'
     # /usr/local/rvm/gems/ruby-1.8.7-p302/gems/httpi-0.7.5/lib/httpi/auth/ssl.rb:61:in`cert_key'
     # /usr/local/rvm/gems/ruby-1.8.7-p302/gems/httpi-0.7.5/lib/httpi/adapter/net_http.rb:86:in `setup_ssl_auth'
     # /usr/local/rvm/gems/ruby-1.8.7-p302/gems/httpi-0.7.5/lib/httpi/adapter/net_http.rb:72:in`do_request'
     # /usr/local/rvm/gems/ruby-1.8.7-p302/gems/httpi-0.7.5/lib/httpi/adapter/net_http.rb:22:in `get'

It's because it tries to open the "nil" file and says WTF!! The commit I sent to you seems to do the job. I tried to make a test but given the way you are mocking it was a little hard, too many things had to be added.
