### PR TITLE
Curb expects cert type to be PEM or DER

### DIFF
--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -79,6 +79,7 @@ module HTTPI
         client.cert_key = ssl.cert_key_file
         client.cert = ssl.cert_file
         client.cacert = ssl.ca_cert_file if ssl.ca_cert_file
+        client.certtype = ssl.cert_type.to_s.upcase
         client.ssl_verify_peer = ssl.verify_mode == :peer
       end
 

--- a/lib/httpi/auth/ssl.rb
+++ b/lib/httpi/auth/ssl.rb
@@ -9,6 +9,7 @@ module HTTPI
     class SSL
 
       VERIFY_MODES = [:none, :peer, :fail_if_no_peer_cert, :client_once]
+      CERT_TYPES = [:pem, :der]
 
       # Returns whether SSL configuration is present.
       def present?
@@ -16,7 +17,7 @@ module HTTPI
       rescue TypeError, Errno::ENOENT
         false
       end
-
+      
       # Accessor for the cert key file to validate SSL certificates.
       attr_accessor :cert_key_file
 
@@ -28,7 +29,18 @@ module HTTPI
 
       # Accessor for the cacert file to validate SSL certificates.
       attr_accessor :ca_cert_file
-
+      
+      # Returns the cert type to validate SSL certificates PEM|DER.
+      def cert_type
+        @cert_type ||= :pem
+      end
+      
+      # Sets the cert type to validate SSL certificates PEM|DER.
+      def cert_type=(type)
+        raise ArgumentError, "Invalid SSL cert type: #{type}" unless CERT_TYPES.include? type
+        @cert_type = type
+      end
+      
       # Returns the SSL verify mode. Defaults to <tt>:peer</tt>.
       def verify_mode
         @verify_mode ||= :peer

--- a/spec/httpi/adapter/curb_spec.rb
+++ b/spec/httpi/adapter/curb_spec.rb
@@ -199,6 +199,14 @@ describe HTTPI::Adapter::Curb do
         curb.expects(:cert_key=).with(ssl_auth_request.auth.ssl.cert_key_file)
         curb.expects(:cert=).with(ssl_auth_request.auth.ssl.cert_file)
         curb.expects(:ssl_verify_peer=).with(true)
+        curb.expects(:certtype=).with(ssl_auth_request.auth.ssl.cert_type.to_s.upcase)
+        
+        adapter.get(ssl_auth_request)
+      end
+      
+      it "should set the cert_type to DER if specified" do
+        ssl_auth_request.auth.ssl.cert_type = :der
+        curb.expects(:certtype=).with(:der.to_s.upcase)
         
         adapter.get(ssl_auth_request)
       end


### PR DESCRIPTION
Curb fails if you don't provide a cert type.

I've added this setting to the ssl settings and made sure it's send to curb.

Tests included

Greetz Benoist
