### PR TITLE
Fix exceptions masked by #decoded_gzip_body

### DIFF
--- a/lib/httpi/response.rb
+++ b/lib/httpi/response.rb
@@ -68,9 +68,10 @@ module HTTPI
     # Returns the gzip decoded response body.
     def decoded_gzip_body
       gzip = Zlib::GzipReader.new StringIO.new(raw_body)
+      raise ArgumentError.new "couldn't create gzip reader" unless gzip
       gzip.read
     ensure
-      gzip.close
+      gzip.close if gzip
     end
 
     # Returns the DIME decoded response body.

--- a/spec/httpi/response_spec.rb
+++ b/spec/httpi/response_spec.rb
@@ -79,6 +79,12 @@ describe HTTPI::Response do
       it "should return the (gzip decoded) HTTP response body" do
         response.body.should == Fixture.xml
       end
+
+      it "should bubble Zlib errors" do
+        arbitrary_error = Class.new(ArgumentError)
+        Zlib::GzipReader.expects(:new).raises(arbitrary_error)
+        lambda { response.body }.should raise_error(arbitrary_error)
+      end
     end
 
     describe "#raw_body" do


### PR DESCRIPTION
This fixes issue #18: https://github.com/rubiii/httpi/issues#issue/18
