### PR TITLE
Added NTLM support

### DIFF
--- a/httpi.gemspec
+++ b/httpi.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = s.name
 
   s.add_dependency "rack"
+  s.add_dependency "ntlm-http", ">= 0.1.1"
 
   s.add_development_dependency "httpclient", "~> 2.1.5"
   s.add_development_dependency "curb", "~> 0.7.8"

--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -59,6 +59,7 @@ module HTTPI
         basic_setup request
         setup_http_auth request if request.auth.http?
         setup_ssl_auth request.auth.ssl if request.auth.ssl?
+        setup_ntlm_auth request if request.auth.ntlm?
       end
 
       def basic_setup(request)
@@ -81,6 +82,11 @@ module HTTPI
         client.cacert = ssl.ca_cert_file if ssl.ca_cert_file
         client.certtype = ssl.cert_type.to_s.upcase
         client.ssl_verify_peer = ssl.verify_mode == :peer
+      end
+      
+      def setup_ntlm_auth(request)
+        client.username, client.password = *request.auth.credentials
+        client.http_auth_types = request.auth.type
       end
 
       def respond_with(client)

--- a/lib/httpi/adapter/httpclient.rb
+++ b/lib/httpi/adapter/httpclient.rb
@@ -68,6 +68,7 @@ module HTTPI
         basic_setup request
         setup_http_auth request if request.auth.http?
         setup_ssl_auth request.auth.ssl if request.auth.ssl?
+        setup_ntlm_auth request if request.auth.ntlm?
       end
 
       def basic_setup(request)
@@ -77,6 +78,10 @@ module HTTPI
       end
 
       def setup_http_auth(request)
+        client.set_auth request.url, *request.auth.credentials
+      end
+      
+      def setup_ntlm_auth(request)
         client.set_auth request.url, *request.auth.credentials
       end
 

--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -1,5 +1,6 @@
 require "uri"
 require "httpi/response"
+require "net/ntlm_http"
 
 module HTTPI
   module Adapter
@@ -9,7 +10,7 @@ module HTTPI
     # Adapter for the Net::HTTP client.
     # http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/
     class NetHTTP
-
+      
       def initialize(request)
         self.client = new_client request
       end
@@ -88,6 +89,7 @@ module HTTPI
         client.ca_file = ssl.ca_cert_file if ssl.ca_cert_file
         client.verify_mode = ssl.openssl_verify_mode
       end
+      
 
       def request_client(type, request)
         request_class = case type
@@ -99,7 +101,10 @@ module HTTPI
         end
         
         request_client = request_class.new request.url.request_uri, request.headers
+        
         request_client.basic_auth *request.auth.credentials if request.auth.basic?
+        request_client.ntlm_auth *request.auth.credentials if request.auth.ntlm?
+        
         request_client
       end
 

--- a/lib/httpi/auth/config.rb
+++ b/lib/httpi/auth/config.rb
@@ -10,7 +10,22 @@ module HTTPI
     class Config
 
       # Supported authentication types.
-      TYPES = [:basic, :digest, :ssl]
+      TYPES = [:basic, :digest, :ssl, :ntlm]
+
+
+      # Accessor for the NTLM auth credentials.
+      def ntlm(*args)
+        return @ntlm if args.empty?
+
+        self.type = :ntlm
+        @ntlm = args.flatten.compact
+      end
+      
+      # Returns whether to use NTLM auth.
+      def ntlm?
+        type == :ntlm
+      end
+
 
       # Accessor for the HTTP basic auth credentials.
       def basic(*args)


### PR DESCRIPTION
The net_http adapter requires the ntlm_http gem. Curb and httpclient both support NTLM out of the box.

Not really sure how best to go about testing this functionality, though.
