### PR TITLE
Failing tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem "jruby-openssl", :platforms => :jruby
 # http clients
 gem "httpclient", "~> 2.1.7"
 gem "curb", "~> 0.7.8", :platforms => :ruby
+gem "mock-server", :git => "https://github.com/djanowski/mock-server.git"

--- a/httpi.gemspec
+++ b/httpi.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "autotest"
   s.add_development_dependency "mocha",       "~> 0.9.9"
   s.add_development_dependency "webmock",     "~> 1.4.0"
-  s.add_development_dependency "mock-server", "~> 0.1.1"
 
   s.files = `git ls-files`.split("\n")
   s.require_path = "lib"

--- a/spec/integration/request_spec.rb
+++ b/spec/integration/request_spec.rb
@@ -77,7 +77,7 @@ describe HTTPI do
     end
   end
 
-  HTTPI::Adapter.adapters.keys.each do |adapter|
+  HTTPI::Adapter::ADAPTERS.keys.each do |adapter|
     context "using :#{adapter}" do
       let(:adapter) { adapter }
       it_should_behave_like "an HTTP client"
@@ -85,7 +85,7 @@ describe HTTPI do
     end
   end
 
-  (HTTPI::Adapter.adapters.keys - [:net_http]).each do |adapter|
+  (HTTPI::Adapter::ADAPTERS.keys - [:net_http]).each do |adapter|
     context "using :#{adapter}" do
       let(:adapter) { adapter }
       it_should_behave_like "it works with HTTP digest auth"


### PR DESCRIPTION
Ran into some test failures:
- undefined method adapters on HTTPI::Adapter
- wrong # of arguments (2 for 1) on Mockserver

Looks like the gem version of Mockserver is different than github.
