### PR TITLE
Initial solution for Savon Issue #197 (multi-part SOAP responses support)

### DIFF
--- a/lib/httpi/response.rb
+++ b/lib/httpi/response.rb
@@ -34,7 +34,6 @@ module HTTPI
 
     # Returns the multi-part boundary marker
     def multipart_boundary
-	#md = headers["Content-Type"].match(/.*boundary=\\"([^\\]*)\\".*/)
         md = headers["Content-Type"].match(/.*boundary=\"([^\"]*)\"/)
 	md.nil? ? nil : md[1]
     end


### PR DESCRIPTION
This permits to add an accessor to the multi-part boundary tag.
