### PR TITLE
Fixing ssl so that cert and cert_key can be manually set

### DIFF
--- a/lib/httpi/auth/ssl.rb
+++ b/lib/httpi/auth/ssl.rb
@@ -54,7 +54,7 @@ module HTTPI
 
       # Returns an <tt>OpenSSL::X509::Certificate</tt> for the +cert_file+.
       def cert
-        @cert ||= OpenSSL::X509::Certificate.new File.read(cert_file) if cert_file
+        @cert ||= (OpenSSL::X509::Certificate.new File.read(cert_file) if cert_file)
       end
 
       # Sets the +OpenSSL+ certificate.
@@ -70,7 +70,7 @@ module HTTPI
 
       # Returns an <tt>OpenSSL::PKey::RSA</tt> for the +cert_key_file+.
       def cert_key
-        @cert_key ||= OpenSSL::PKey::RSA.new(File.read(cert_key_file), cert_key_password) if cert_key_file
+        @cert_key ||= (OpenSSL::PKey::RSA.new(File.read(cert_key_file), cert_key_password) if cert_key_file)
       end
 
       # Sets the +OpenSSL+ certificate key.

--- a/spec/httpi/auth/ssl_spec.rb
+++ b/spec/httpi/auth/ssl_spec.rb
@@ -66,6 +66,13 @@ describe HTTPI::Auth::SSL do
       ssl = HTTPI::Auth::SSL.new
       ssl.cert.should be_nil
     end
+
+    it "returns the explicitly given certificate if set" do
+      ssl = HTTPI::Auth::SSL.new
+      cert = OpenSSL::X509::Certificate.new 
+      ssl.cert = cert
+      ssl.cert.should == cert
+    end
   end
 
   describe "#cert_key" do
@@ -76,6 +83,13 @@ describe HTTPI::Auth::SSL do
     it "returns nil if no cert_key_file was given" do
       ssl = HTTPI::Auth::SSL.new
       ssl.cert_key.should be_nil
+    end
+
+    it "returns the explicitly given key if set" do
+      ssl = HTTPI::Auth::SSL.new
+      key = OpenSSL::PKey::RSA.new 
+      ssl.cert_key = key
+      ssl.cert_key.should == key
     end
   end
 


### PR DESCRIPTION
Hi,

I'm getting my ssl key and certificate from an instance of OpenSSL::PKCS12 so I'm manually setting cert and cert_key on HTTPI::Auth::SSL. The code for the read side of these properties meant that unless cert_file is also set, they will always return nil. So when HTTPI::Auth::SSL.present? is called it returns false and ssl is not used for my connection.

I've fixed the readers and added a couple of tests to prove it works.
