### PR TITLE
Ability to set SSL version explicitly

### DIFF
--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -81,6 +81,7 @@ module HTTPI
         client.cacert = ssl.ca_cert_file if ssl.ca_cert_file
         client.certtype = ssl.cert_type.to_s.upcase
         client.ssl_verify_peer = ssl.verify_mode == :peer
+        client.ssl_version = (ssl.ssl_version == :TLSv1 ? 1 : (ssl.ssl_version == :SSLv2 ? 2 : 3)) if ssl.ssl_version
       end
 
       def respond_with(client)

--- a/lib/httpi/auth/ssl.rb
+++ b/lib/httpi/auth/ssl.rb
@@ -10,6 +10,7 @@ module HTTPI
 
       VERIFY_MODES = [:none, :peer, :fail_if_no_peer_cert, :client_once]
       CERT_TYPES = [:pem, :der]
+      SSL_VERSIONS = [:TLSv1, :SSLv2, :SSLv3]
 
       # Returns whether SSL configuration is present.
       def present?
@@ -50,6 +51,17 @@ module HTTPI
       def verify_mode=(mode)
         raise ArgumentError, "Invalid SSL verify mode: #{mode}" unless VERIFY_MODES.include? mode
         @verify_mode = mode
+      end
+
+      # Returns the SSL version number. Defaults to <tt>nil</tt> (auto-negotiate).
+      def ssl_version
+        @ssl_version
+      end
+
+      # Sets the SSL version number. Expects one of <tt>HTTPI::Auth::SSL::SSL_VERSIONS</tt>.
+      def ssl_version=(version)
+        raise ArgumentError, "Invalid SSL version: #{version}" unless SSL_VERSIONS.include? version
+        @ssl_version = version
       end
 
       # Returns an <tt>OpenSSL::X509::Certificate</tt> for the +cert_file+.


### PR DESCRIPTION
I had live nightmare this night.
I had to set SSL version to TLS v1 for one important service using Savon.
On ruby 1.8.7 EE it worked nicely, but 1.9.3 uses "SSLv23" auto-negotiate by default, which results in SSL verify errors.

And since Savon uses HTTPI I couldn't set this version no matter how hard I tried.
So I went monkeypatching frenzy.

This patch is not complete (e.g. it doesn't set ssl version on Net::HTTP and HTTPClient adapters), but its just a demo how I did this and I want you to see if it's a good idea to add this functionality.
