### PR TITLE
Auth::SSL #cert= and #cert_key= ignored

### DIFF
--- a/lib/httpi/auth/ssl.rb
+++ b/lib/httpi/auth/ssl.rb
@@ -54,7 +54,7 @@ module HTTPI
 
       # Returns an <tt>OpenSSL::X509::Certificate</tt> for the +cert_file+.
       def cert
-        @cert ||= OpenSSL::X509::Certificate.new File.read(cert_file) if cert_file
+        @cert ||= (OpenSSL::X509::Certificate.new File.read(cert_file) if cert_file)
       end
 
       # Sets the +OpenSSL+ certificate.
@@ -70,7 +70,7 @@ module HTTPI
 
       # Returns an <tt>OpenSSL::PKey::RSA</tt> for the +cert_key_file+.
       def cert_key
-        @cert_key ||= OpenSSL::PKey::RSA.new(File.read(cert_key_file), cert_key_password) if cert_key_file
+        @cert_key ||= (OpenSSL::PKey::RSA.new(File.read(cert_key_file), cert_key_password) if cert_key_file)
       end
 
       # Sets the +OpenSSL+ certificate key.

--- a/spec/httpi/auth/ssl_spec.rb
+++ b/spec/httpi/auth/ssl_spec.rb
@@ -66,6 +66,13 @@ describe HTTPI::Auth::SSL do
       ssl = HTTPI::Auth::SSL.new
       ssl.cert.should be_nil
     end
+
+    it "returns the value set by #cert=" do
+      ssl = HTTPI::Auth::SSL.new
+
+      ssl.cert = 'abc123'
+      ssl.cert.should == 'abc123'
+    end
   end
 
   describe "#cert_key" do
@@ -77,6 +84,13 @@ describe HTTPI::Auth::SSL do
       ssl = HTTPI::Auth::SSL.new
       ssl.cert_key.should be_nil
     end
+
+    it "returns the value set by #cert_key=" do
+      ssl = HTTPI::Auth::SSL.new
+
+      ssl.cert_key = 'abc123'
+      ssl.cert_key.should == 'abc123'
+    end
   end
 
   describe "#ca_cert" do
@@ -85,6 +99,13 @@ describe HTTPI::Auth::SSL do
 
       ssl.ca_cert_file = "spec/fixtures/client_cert.pem"
       ssl.ca_cert.should be_a(OpenSSL::X509::Certificate)
+    end
+
+    it "returns the value set by #ca_cert=" do
+      ssl = HTTPI::Auth::SSL.new
+
+      ssl.ca_cert = 'abc123'
+      ssl.ca_cert.should == 'abc123'
     end
   end
 


### PR DESCRIPTION
I found the following:

```
ssl = HTTPI::Auth::SSL.new
ssl.cert = 'abc123'
ss.cert # => nil

ssl = HTTPI::Auth::SSL.new
ssl.cert_key = 'abc123'
ss.cert # => nil
```

This patch fixes the memoization and nil detection precedence in SSL.
