### PR TITLE
Header "Cookie" can erroneously be nil (not missing)

### DIFF
--- a/lib/httpi/request.rb
+++ b/lib/httpi/request.rb
@@ -66,7 +66,8 @@ module HTTPI
     # Sets the cookies from a given +http_response+.
     def set_cookies(http_response)
       cookie_store.add *http_response.cookies
-      headers["Cookie"] = cookie_store.fetch
+	  cookies = cookie_store.fetch
+      headers["Cookie"] = cookies if cookies
     end
 
     attr_accessor :open_timeout, :read_timeout

--- a/spec/httpi/request_spec.rb
+++ b/spec/httpi/request_spec.rb
@@ -115,7 +115,7 @@ describe HTTPI::Request do
 
     it "doesn't do anything if the response contains no cookies" do
       request.set_cookies HTTPI::Response.new(200, {}, "")
-      request.headers["Cookie"].should be_nil
+      request.headers.key?("Cookie").should == false
     end
 
     def response_with_cookie(cookie)


### PR DESCRIPTION
When there are no cookies, the "Cookies" key shouldn't exist.  The
existing behaviour was to allow it to be nil.

initialize_http_header in module HTTPHeader (net/http.rb) iterates over
all headers.  When "Cookie" is set and is nil, this method freaks out
when trying to call value.strip.  If the "Cookie" header has a value of
nil, it should not be included in the headers hash.
