### PR TITLE
Support multiple CA certificates in a single file

### DIFF
--- a/lib/httpi/adapter/httpclient.rb
+++ b/lib/httpi/adapter/httpclient.rb
@@ -87,6 +87,7 @@ module HTTPI
           client.ssl_config.client_ca = ssl.ca_cert if ssl.ca_cert_file
         end
         client.ssl_config.verify_mode = ssl.openssl_verify_mode
+        client.ssl_config.set_trust_ca = ssl.ca_cert_file if ssl.ca_cert_file
       end
 
       def respond_with(response)


### PR DESCRIPTION
This lets me point ssl.ca_cert_file at the system CA certificate store (multiple concatenated PEM certificates, /etc/ssl/certs/ca-certificates.crt on Debian) to avoid an SSL verification error "at depth 0 - 20: unable to get local issuer certificate".

I'm using HTTPI indirectly via savon-1.1.0 and simple_crowd-1.2.1 on Debian. My way to set the CA file is this:

``` ruby
require 'simple_crowd'
crowd = SimpleCrowd::Client.new(
  :service_url => 'https://crowd.example.com/',
  :app_name => 'foo',
  :app_password => 'bar')
crowd.send(:client).http.auth.ssl.ca_cert_file = '/etc/ssl/certs/ca-certificates.crt'
crowd.find_user_by_name 'joe'
```

Reference: https://github.com/rubiii/httpi/issues/26#issuecomment-4280217
