### PR TITLE
Make SSL work with httpclient adapter

### DIFF
--- a/lib/httpi/adapter/httpclient.rb
+++ b/lib/httpi/adapter/httpclient.rb
@@ -84,7 +84,7 @@ module HTTPI
         unless ssl.verify_mode == :none
           client.ssl_config.client_cert = ssl.cert
           client.ssl_config.client_key = ssl.cert_key
-          client.ssl_config.client_ca = ssl.ca_cert if ssl.ca_cert_file
+          client.ssl_config.add_trust_ca(ssl.ca_cert_file) if ssl.ca_cert_file
         end
         client.ssl_config.verify_mode = ssl.openssl_verify_mode
         client.ssl_config.ssl_version = ssl.ssl_version if ssl.ssl_version

--- a/spec/httpi/adapter/httpclient_spec.rb
+++ b/spec/httpi/adapter/httpclient_spec.rb
@@ -117,7 +117,7 @@ describe HTTPI::Adapter::HTTPClient do
 
       it "sets the client_ca if specified" do
         ssl_auth_request.auth.ssl.ca_cert_file = "spec/fixtures/client_cert.pem"
-        ssl_config.expects(:client_ca=).with(ssl_auth_request.auth.ssl.ca_cert)
+        ssl_config.expects(:add_trust_ca).with(ssl_auth_request.auth.ssl.ca_cert_file)
 
         adapter.get(ssl_auth_request)
       end


### PR DESCRIPTION
Trusted CA certificates must be set with SSLConfig#add_trust_ca.
SSLConfig#client_ca is for SSL Server setting so meaningless for SSL
client.  I must have not added the property... (I used the class as
well for SSL Server.)

By the way, ca_cert_file usualy contains multiple certificates (cat
*.pem > ca_cert_file.pem) so Auth::SSL#cert_file should be useless, too.
Better check other adapter impls.

Thanks for using httpclient as an adapter!
