### PR TITLE
Allow to set query parameter of url on Request

### DIFF
--- a/lib/httpi/request.rb
+++ b/lib/httpi/request.rb
@@ -31,6 +31,21 @@ module HTTPI
     # Returns the +url+ to access.
     attr_reader :url
 
+    # Sets the +query+ from +url+. Raises an +ArgumentError+ unless the +url+ is valid.
+    def query=(query)
+      raise ArgumentError, "Invalid URL: #{self.url}" unless self.url.respond_to?(:query)
+      if query.kind_of?(Hash)
+        query = Rack::Utils.build_query(query)
+      end
+      query = query.to_s unless query.is_a?(String)
+      self.url.query = query
+    end
+
+    # Returns the +query+ from +url+.
+    def query
+      self.url.query if self.url.respond_to?(:query)
+    end
+
     # Sets the +proxy+ to use. Raises an +ArgumentError+ unless the +proxy+ is valid.
     def proxy=(proxy)
       @proxy = normalize_url! proxy

--- a/spec/httpi/request_spec.rb
+++ b/spec/httpi/request_spec.rb
@@ -43,6 +43,35 @@ describe HTTPI::Request do
     end
   end
 
+  describe "#query" do
+    it "raises an ArgumentError if url not respond to query" do
+      expect { request.query = "q=query" }.to raise_error(ArgumentError)
+    end
+    it "lets you specify query parameter as String" do
+      request.url = "http://example.com"
+      request.query = "q=query"
+      request.url.to_s.should == "http://example.com?q=query"
+    end
+    it "lets you specify query parameter as Hash" do
+      request.url = "http://example.com"
+      request.query = {:q => "query"}
+      request.url.to_s.should == "http://example.com?q=query"
+    end
+    it "getter return nil for invalid url" do
+      request.query.should be_nil
+    end
+    it "getter return String for query parameter as String" do
+      request.url = "http://example.com"
+      request.query = "q=query"
+      request.query.should == "q=query"
+    end
+    it "getter return String for query parameter as Hash" do
+      request.url = "http://example.com"
+      request.query = {:q => "query"}
+      request.query.should == "q=query"
+    end
+  end
+
   describe "#proxy" do
     it "lets you specify the proxy URL to use as a String" do
       request.proxy = "http://proxy.example.com"


### PR DESCRIPTION
req = HTTPI::Request.new("http://example.com")
req.query = "q=query"
req.query = {:q => "query"}
req.url.to_s  # => "http://example.com?q=query"

During development of [http_monkey](https://github.com/rogerleite/http_monkey), i think would be cool to have this feature.
