### PR TITLE
Fix request does not yield adapter client

### DIFF
--- a/lib/httpi.rb
+++ b/lib/httpi.rb
@@ -96,33 +96,33 @@ module HTTPI
   class << self
 
     # Executes an HTTP GET request.
-    def get(request, adapter = nil)
+    def get(request, adapter = nil, &block)
       request = Request.new(request) if request.kind_of? String
-      request(:get, request, adapter)
+      request(:get, request, adapter, &block)
     end
 
     # Executes an HTTP POST request.
-    def post(*args)
+    def post(*args, &block)
       request, adapter = request_and_adapter_from(args)
-      request(:post, request, adapter)
+      request(:post, request, adapter, &block)
     end
 
     # Executes an HTTP HEAD request.
-    def head(request, adapter = nil)
+    def head(request, adapter = nil, &block)
       request = Request.new(request) if request.kind_of? String
-      request(:head, request, adapter)
+      request(:head, request, adapter, &block)
     end
 
     # Executes an HTTP PUT request.
-    def put(*args)
+    def put(*args, &block)
       request, adapter = request_and_adapter_from(args)
-      request(:put, request, adapter)
+      request(:put, request, adapter, &block)
     end
 
     # Executes an HTTP DELETE request.
-    def delete(request, adapter = nil)
+    def delete(request, adapter = nil, &block)
       request = Request.new(request) if request.kind_of? String
-      request(:delete, request, adapter)
+      request(:delete, request, adapter, &block)
     end
 
     # Executes an HTTP request for the given +method+.

--- a/spec/httpi/httpi_spec.rb
+++ b/spec/httpi/httpi_spec.rb
@@ -202,8 +202,12 @@ describe HTTPI do
           context "using #{adapter}" do
             before { opts[:class].any_instance.expects(:request).with(method) }
 
-            it "yields the HTTP client instance used for the request" do
+            it "#request yields the HTTP client instance" do
               expect { |b| client.request(method, request, adapter, &b) }.to yield_with_args(client_class[adapter].call)
+            end
+
+            it "##{method} yields the HTTP client instance" do
+              expect { |b| client.send(method, request, adapter, &b) }.to yield_with_args(client_class[adapter].call)
             end
           end
         end


### PR DESCRIPTION
This commit allow the code below to work. More details in issue #68

``` ruby
    response = HTTPI.get(request, :curb) do |client|
      client.follow_location = true
    end
    puts response.code  # => 200
```
