### PR TITLE
Standardize Response Headers from all Adapters

### DIFF
--- a/lib/httpi/adapter/httpclient.rb
+++ b/lib/httpi/adapter/httpclient.rb
@@ -63,7 +63,15 @@ module HTTPI
       end
 
       def respond_with(response)
-        Response.new response.code, Hash[*response.header.all.flatten], response.content
+        headers = {}
+        response.header.all.each do |(header, value)|
+          if headers.key?(header)
+            headers[header] = Array(headers[header]) << value
+          else
+            headers[header] = value
+          end
+        end
+        Response.new response.code, headers, response.content
       end
 
     end

--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -92,7 +92,9 @@ module HTTPI
 
       def respond_with(response)
         headers = response.to_hash
-        headers.each { |key, value| headers[key] = value[0] }
+        headers.each do |key, value|
+          headers[key] = value[0] if value.size <= 1
+        end
         Response.new response.code, headers, response.body
       end
 

--- a/spec/integration/curb_spec.rb
+++ b/spec/integration/curb_spec.rb
@@ -25,6 +25,14 @@ describe HTTPI::Adapter::Curb do
         response.body.should include("HTTPI")
       end
 
+      it "it supports headers with multiple values" do
+        request = HTTPI::Request.new(@server.url + "cookies")
+
+        response = HTTPI.get(request, adapter)
+        cookies = ["cookie1=chip1; path=/", "cookie2=chip2; path=/"]
+        response.headers["Set-Cookie"].should eq(cookies)
+      end
+
       it "executes GET requests" do
         response = HTTPI.get(@server.url, adapter)
         response.body.should eq("get")

--- a/spec/integration/em_http_spec.rb
+++ b/spec/integration/em_http_spec.rb
@@ -34,6 +34,14 @@ describe HTTPI::Adapter::EmHttpRequest do
         response.body.should include("HTTPI")
       end
 
+      it "it supports headers with multiple values" do
+        request = HTTPI::Request.new(@server.url + "cookies")
+
+        response = HTTPI.get(request, adapter)
+        cookies = ["cookie1=chip1; path=/", "cookie2=chip2; path=/"]
+        response.headers["Set-Cookie"].should eq(cookies)
+      end
+
       it "executes GET requests" do
         response = HTTPI.get(@server.url, adapter)
         response.body.should eq("get")

--- a/spec/integration/httpclient_spec.rb
+++ b/spec/integration/httpclient_spec.rb
@@ -22,6 +22,14 @@ describe HTTPI::Adapter::HTTPClient do
       response.body.should include("HTTPI")
     end
 
+    it "it supports headers with multiple values" do
+      request = HTTPI::Request.new(@server.url + "cookies")
+
+      response = HTTPI.get(request, adapter)
+      cookies = ["cookie1=chip1; path=/", "cookie2=chip2; path=/"]
+      response.headers["Set-Cookie"].should eq(cookies)
+    end
+
     it "executes GET requests" do
       response = HTTPI.get(@server.url, adapter)
       response.body.should eq("get")

--- a/spec/integration/net_http_spec.rb
+++ b/spec/integration/net_http_spec.rb
@@ -22,6 +22,14 @@ describe HTTPI::Adapter::NetHTTP do
       response.body.should include("HTTPI")
     end
 
+    it "it supports headers with multiple values" do
+      request = HTTPI::Request.new(@server.url + "cookies")
+
+      response = HTTPI.get(request, adapter)
+      cookies = ["cookie1=chip1; path=/", "cookie2=chip2; path=/"]
+      response.headers["Set-Cookie"].should eq(cookies)
+    end
+
     it "executes GET requests" do
       response = HTTPI.get(@server.url, adapter)
       response.body.should eq("get")

--- a/spec/integration/support/application.rb
+++ b/spec/integration/support/application.rb
@@ -26,6 +26,17 @@ class IntegrationServer
       }
     end
 
+    map "/cookies" do
+      run lambda { |env|
+        status, headers, body = IntegrationServer.respond_with("Many Cookies")
+        response = Rack::Response.new(body, status, headers)
+
+        response.set_cookie("cookie1", {:value => "chip1", :path => "/"})
+        response.set_cookie("cookie2", {:value => "chip2", :path => "/"})
+        response.finish
+      }
+    end
+
     map "/basic-auth" do
       use Rack::Auth::Basic, "basic-realm" do |username, password|
         username == "admin" && password == "secret"


### PR DESCRIPTION
Now, all adapters returns Array when response have more than one header.
Used `Set-Cookie` for example on tests.

This commit, fix issue #69 and closes pull request #52.
