### PR TITLE
Rack adapter

### DIFF
--- a/lib/httpi.rb
+++ b/lib/httpi.rb
@@ -7,6 +7,7 @@ require "httpi/adapter/httpclient"
 require "httpi/adapter/curb"
 require "httpi/adapter/net_http"
 require "httpi/adapter/em_http"
+require "httpi/adapter/rack"
 
 # = HTTPI
 #

--- a/lib/httpi/adapter/rack.rb
+++ b/lib/httpi/adapter/rack.rb
@@ -1,0 +1,92 @@
+require 'httpi/adapter/base'
+require 'httpi/response'
+
+module HTTPI
+  module Adapter
+
+    # = HTTPI::Adapter::Rack
+    #
+    # Adapter for Rack::MockRequest.
+    # Due to limitations, not all features are supported.
+    # https://github.com/rack/rack/blob/master/lib/rack/mock.rb
+    #
+    # Usage:
+    #
+    #   HTTPI::Adapter::Rack.mount 'application', RackApplication
+    #   HTTPI.get("http://application/path", :rack)
+    class Rack < Base
+      register :rack, :deps => %w(rack/mock)
+
+      attr_reader :client
+
+      class << self
+        attr_accessor :mounted_apps
+      end
+
+      self.mounted_apps = {}
+
+      # Attaches Rack endpoint at specified host.
+      # Endpoint will be acessible at {http://host/ http://host/} url.
+      def self.mount(host, application)
+        self.mounted_apps[host] = application
+      end
+
+      # Removes Rack endpoint.
+      def self.unmount(host)
+        self.mounted_apps.delete(host)
+      end
+
+      def initialize(request)
+        @app = self.class.mounted_apps[request.url.host]
+
+
+        if @app.nil?
+          message  = "Application '#{request.url.host}' not mounted: ";
+          message += "use `HTTPI::Adapter::Rack.mount('#{request.url.host}', RackApplicationClass)`"
+
+          raise message
+        end
+
+        @request = request
+        @client  = ::Rack::MockRequest.new(@app)
+      end
+
+      # Executes arbitrary HTTP requests.
+      # You have to mount required Rack application before you can use it.
+      #
+      # @see .mount
+      # @see HTTPI.request
+      def request(method)
+        unless REQUEST_METHODS.include? method
+          raise NotSupportedError, "Rack adapter does not support custom HTTP methods"
+        end
+
+        env = {}
+        @request.headers.each do |header, value|
+          env["HTTP_#{header.gsub('-', '_').upcase}"] = value
+        end
+
+        if @request.proxy
+          raise NotSupportedError, "Rack adapter does not support proxying"
+        end
+
+        if @request.auth.http?
+          raise NotSupportedError, "Rack adapter does not support HTTP auth"
+        end
+
+        if @request.auth.ssl?
+          raise NotSupportedError, "Rack adapter does not support SSL client auth"
+        end
+
+        if @request.on_body
+          raise NotSupportedError, "Rack adapter does not support response streaming"
+        end
+
+        response = @client.request(method.to_s.upcase, @request.url.to_s,
+              { :fatal => true, :input => @request.body.to_s }.merge(env))
+
+        Response.new(response.status, response.headers, response.body)
+      end
+    end
+  end
+end

--- a/spec/httpi/adapter/rack_spec.rb
+++ b/spec/httpi/adapter/rack_spec.rb
@@ -1,0 +1,111 @@
+require "spec_helper"
+require "integration/support/application"
+
+describe HTTPI::Adapter::NetHTTP do
+
+  subject(:adapter) { :rack }
+
+  context "http requests" do
+    before :all do
+      @app = 'app'
+      @url = "http://#{@app}/"
+
+      HTTPI::Adapter::Rack.mount @app, IntegrationServer::Application
+    end
+
+    it "sends and receives HTTP headers" do
+      request = HTTPI::Request.new(@url + "x-header")
+      request.headers["X-Header"] = "HTTPI"
+
+      response = HTTPI.get(request, adapter)
+      response.body.should include("HTTPI")
+    end
+
+    it "executes GET requests" do
+      response = HTTPI.get(@url, adapter)
+      response.body.should eq("get")
+      response.headers["Content-Type"].should eq("text/plain")
+    end
+
+    it "executes POST requests" do
+      response = HTTPI.post(@url, "<some>xml</some>", adapter)
+      response.body.should eq("post")
+      response.headers["Content-Type"].should eq("text/plain")
+    end
+
+    it "executes HEAD requests" do
+      response = HTTPI.head(@url, adapter)
+      response.code.should == 200
+      response.headers["Content-Type"].should eq("text/plain")
+    end
+
+    it "executes PUT requests" do
+      response = HTTPI.put(@url, "<some>xml</some>", adapter)
+      response.body.should eq("put")
+      response.headers["Content-Type"].should eq("text/plain")
+    end
+
+    it "executes DELETE requests" do
+      response = HTTPI.delete(@url, adapter)
+      response.body.should eq("delete")
+      response.headers["Content-Type"].should eq("text/plain")
+    end
+
+    describe "settings:" do
+
+      let(:request) { HTTPI::Request.new("http://#{@app}") }
+      let(:client)  { HTTPI::Adapter::Rack.new(request) }
+
+      describe "proxy" do
+        before do
+          request.proxy = "http://proxy-host.com:443"
+          request.proxy.user = "username"
+          request.proxy.password = "password"
+        end
+
+        it "is not supported" do
+          expect { client.request(:get) }.
+            to raise_error(HTTPI::NotSupportedError, "Rack adapter does not support proxying")
+        end
+      end
+
+      describe "on_body" do
+        before do
+          request.on_body do
+            # ola-la!
+          end
+        end
+
+        it "is not supported" do
+          expect { client.request(:get) }.
+            to raise_error(HTTPI::NotSupportedError, "Rack adapter does not support response streaming")
+        end
+      end
+
+      describe "set_auth" do
+        before do
+          request.auth.basic "username", "password"
+        end
+
+        it "is not supported" do
+          expect { client.request(:get) }.
+            to raise_error(HTTPI::NotSupportedError, "Rack adapter does not support HTTP auth")
+        end
+      end
+
+      context "(for SSL client auth)" do
+        before do
+          request.auth.ssl.cert_key_file = "spec/fixtures/client_key.pem"
+          request.auth.ssl.cert_file = "spec/fixtures/client_cert.pem"
+        end
+
+        it "is not supported" do
+          expect { client.request(:get) }.
+            to raise_error(HTTPI::NotSupportedError, "Rack adapter does not support SSL client auth")
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/httpi/httpi_spec.rb
+++ b/spec/httpi/httpi_spec.rb
@@ -14,6 +14,14 @@ describe HTTPI do
   let(:httpclient) { HTTPI::Adapter.load(:httpclient) }
   let(:net_http) { HTTPI::Adapter.load(:net_http) }
 
+  before(:all) do
+    HTTPI::Adapter::Rack.mount('example.com', IntegrationServer::Application)
+  end
+
+  after(:all) do
+    HTTPI::Adapter::Rack.unmount('example.com')
+  end
+
   describe ".adapter=" do
     it "sets the default adapter to use" do
       HTTPI::Adapter.expects(:use=).with(:net_http)
@@ -204,7 +212,8 @@ describe HTTPI do
             :httpclient => lambda { HTTPClient },
             :curb       => lambda { Curl::Easy },
             :net_http   => lambda { Net::HTTP },
-            :em_http    => lambda { EventMachine::HttpConnection }
+            :em_http    => lambda { EventMachine::HttpConnection },
+            :rack       => lambda { Rack::MockRequest }
           }
 
           context "using #{adapter}" do


### PR DESCRIPTION
Rack adapter adds ability to perform internal direct middleware calls. Usage case:

``` ruby
HTTPI::Adapter::Rack.mount 'app', IntegrationServer::Application
result = HTTPI.get("http://app/path", :rack)
```

If you are interested in merging this, I can add corresponding CHANGELOG entry and extend README description.
