### PR TITLE
Fix for issue #81

### DIFF
--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -82,11 +82,13 @@ module HTTPI
         ssl = @request.auth.ssl
 
         unless ssl.verify_mode == :none
-          @client.cert_key = ssl.cert_key_file
-          @client.cert = ssl.cert_file
           @client.cacert = ssl.ca_cert_file if ssl.ca_cert_file
           @client.certtype = ssl.cert_type.to_s.upcase
         end
+
+        # Send client-side certificate regardless of state of SSL verify mode
+        @client.cert_key = ssl.cert_key_file
+        @client.cert = ssl.cert_file
 
         @client.ssl_verify_peer = ssl.verify_mode == :peer
         @client.ssl_version = case ssl.ssl_version

--- a/lib/httpi/adapter/httpclient.rb
+++ b/lib/httpi/adapter/httpclient.rb
@@ -53,10 +53,12 @@ module HTTPI
         ssl = @request.auth.ssl
 
         unless ssl.verify_mode == :none
-          @client.ssl_config.client_cert = ssl.cert
-          @client.ssl_config.client_key = ssl.cert_key
           @client.ssl_config.add_trust_ca(ssl.ca_cert_file) if ssl.ca_cert_file
         end
+
+        # Send client-side certificate regardless of state of SSL verify mode
+        @client.ssl_config.client_cert = ssl.cert
+        @client.ssl_config.client_key = ssl.cert_key
 
         @client.ssl_config.verify_mode = ssl.openssl_verify_mode
         @client.ssl_config.ssl_version = ssl.ssl_version if ssl.ssl_version

--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -91,10 +91,12 @@ module HTTPI
         ssl = @request.auth.ssl
 
         unless ssl.verify_mode == :none
-          @client.key = ssl.cert_key
-          @client.cert = ssl.cert
           @client.ca_file = ssl.ca_cert_file if ssl.ca_cert_file
         end
+
+        # Send client-side certificate regardless of state of SSL verify mode
+        @client.key = ssl.cert_key
+        @client.cert = ssl.cert
 
         @client.verify_mode = ssl.openssl_verify_mode
         @client.ssl_version = ssl.ssl_version if ssl.ssl_version

--- a/spec/httpi/adapter/httpclient_spec.rb
+++ b/spec/httpi/adapter/httpclient_spec.rb
@@ -147,13 +147,6 @@ describe HTTPI::Adapter::HTTPClient do
         adapter.request(:get)
       end
 
-      it "does not set client_cert and client_key "do
-        ssl_config.expects(:client_cert=).never
-        ssl_config.expects(:client_key=).never
-
-        adapter.request(:get)
-      end
-
       it "does not raise an exception" do
         expect { adapter.request(:get) }.to_not raise_error
       end


### PR DESCRIPTION
This fix for issue #81 will allow the adapters with ssl support (net/http, curb, httpclient) to send client-side certificates even when ssl verify mode is set to none.
