### PR TITLE
Use HTTPS in Gemfile source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec
 
 gem "jruby-openssl",                                :platforms => :jruby


### PR DESCRIPTION
According to Bundler:

``` sh
ryguy$ bundle install
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
