### PR TITLE
Use ssl_version as string on httpclient adapter

### DIFF
--- a/lib/httpi/adapter/httpclient.rb
+++ b/lib/httpi/adapter/httpclient.rb
@@ -61,7 +61,7 @@ module HTTPI
         @client.ssl_config.client_key = ssl.cert_key
 
         @client.ssl_config.verify_mode = ssl.openssl_verify_mode
-        @client.ssl_config.ssl_version = ssl.ssl_version if ssl.ssl_version
+        @client.ssl_config.ssl_version = ssl.ssl_version.to_s if ssl.ssl_version
       end
 
       def respond_with(response)

--- a/spec/httpi/adapter/httpclient_spec.rb
+++ b/spec/httpi/adapter/httpclient_spec.rb
@@ -138,7 +138,7 @@ describe HTTPI::Adapter::HTTPClient do
 
       it 'should set the ssl_version if specified' do
         request.auth.ssl.ssl_version = :SSLv3
-        ssl_config.expects(:ssl_version=).with(request.auth.ssl.ssl_version)
+        ssl_config.expects(:ssl_version=).with('SSLv3')
 
         adapter.request(:get)
       end


### PR DESCRIPTION
Fix issue #86 

On others adapters, we don't have to change.
- **EM-HTTP-Request** doesn't support SSL.
- **Net/HTTP** seems [happy with symbols](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-ssl_version-3D)
- **Curb** doesn't have this problem, because [use numbers](https://github.com/savonrb/httpi/blob/master/lib/httpi/adapter/curb.rb#L94).

By now, i'm oficially giving up to find a solution to run jruby with SSL support.
