### PR TITLE
fixed last remaining issues before v2.1.0

### DIFF
--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -110,14 +110,14 @@ module HTTPI
 
           # we need to provide a domain in the packet if an only if it was provided by the user in the auth request
           if @request.auth.ntlm[2]
-            message_builder[:domain] = Net::NTLM.encode_utf16le(@request.auth.ntlm[2].upcase)
+            message_builder[:domain] = Net::NTLM::EncodeUtil.encode_utf16le(@request.auth.ntlm[2].upcase)
           else
             message_builder[:domain] = ''
           end
 
           # we should also provide the workstation name, currently the rubyntlm provider does not automatically
           # set the workstation name
-          message_builder[:workstation] = Net::NTLM.encode_utf16le(Socket.gethostname)
+          message_builder[:workstation] = Net::NTLM::EncodeUtil.encode_utf16le(Socket.gethostname)
           
           ntlm_response = ntlm_message.response(message_builder ,
                                                  {:ntlmv2 => true})

--- a/spec/httpi/adapter/excon_spec.rb
+++ b/spec/httpi/adapter/excon_spec.rb
@@ -61,6 +61,17 @@ describe HTTPI::Adapter::Excon do
     end
 
     it "supports ntlm authentication" do
+      pending "the excon adapter does not yet support NTLM auth"
+      # when excon was added, net-http.rb and net-http-spec.rb seem to have been a starting point.
+      # however, excon doesn't implement the NTLM protocol.  Without an implementation, this is a 
+      # vanilla GET which results in a 401 as designed.
+
+      # compare httpi/lib/httpi/adapter/net_http.rb, 33, 67, 78 (impl of NTLM protocol on top of net_http)
+      # with httpi/lib/httpi/adapter/excon.rb:25 which is a straight passthru to the excon client without NTLM
+      
+      # For the implementation of the Puma test app /ntlm-auth, see httpi/spec/integration/support/application.rb:50
+      # (this is based on recorded exchange as mentioned in httpi/spec/integration/net_http_spec.rb:107)
+
       request = HTTPI::Request.new(@server.url + "ntlm-auth")
       request.auth.ntlm("tester", "vReqSoafRe5O")
 

--- a/spec/httpi/adapter/net_http_persistent_spec.rb
+++ b/spec/httpi/adapter/net_http_persistent_spec.rb
@@ -61,6 +61,17 @@ describe HTTPI::Adapter::NetHTTPPersistent do
     end
 
     it "supports ntlm authentication" do
+      pending "the net_http_persistent adapter does not yet support NTLM auth"
+      # when net_http_persistent was added, net-http.rb and net-http-spec.rb seem to have been a starting point.
+      # however, net_http_persistent doesn't implement the NTLM protocol.  Without an implementation, this is a 
+      # vanilla GET which results in a 401 as designed.
+
+      # compare httpi/lib/httpi/adapter/net_http.rb, 33, 67, 78 (impl of NTLM protocol on top of net_http)
+      # with httpi/lib/httpi/adapter/net_http_persistent.rb:26 which is a straight passthru without NTLM
+      
+      # For the implementation of the Puma test app /ntlm-auth, see httpi/spec/integration/support/application.rb:50
+      # (this is based on recorded exchange as mentioned in httpi/spec/integration/net_http_spec.rb:107)
+
       request = HTTPI::Request.new(@server.url + "ntlm-auth")
       request.auth.ntlm("tester", "vReqSoafRe5O")
 


### PR DESCRIPTION
Hey @rubiii, here's the fixes, build success for all rubies!

The first two errors looked like a copy/paste of net_http_spec.rb as a base for supporting excon and net_http_persistent. Since there was no implementation in either adapter or respective clients, of course these failed.  I've changed the specs to pending and added comments so that contributors can implement NTLM if they want to in the future.  For this release, I think it's sufficient to require net_http for NTLM access.  What do you think?

When I originally added NTLM support to httpi, I targeted net_http as the simplest to get the idea working.  I didn't think it was necessary to support NTLM for all adapters, but I suppose it would be nice.  We might want to pull the NTLM strategy out of net_http in the future so that it can be shared across adapters.  

The 3rd error was simply a problem with namespace that @pmorton must have missed during refactoring.
