### PR TITLE
Removing Net::NTLM::EncodeUtil and using Net::NTLM insteand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
+  - 2.0.0
   - jruby-18mode
   - jruby-19mode
   - rbx-18mode

--- a/httpi.gemspec
+++ b/httpi.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency 'rack'
-  s.add_dependency 'rubyntlm',          '~> 0.3.2'
+  s.add_dependency 'rubyntlm',          '0.3.2'
 
   s.add_development_dependency 'rake',  '~> 10.0'
   s.add_development_dependency 'rspec', '~> 2.12'

--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -110,14 +110,14 @@ module HTTPI
 
           # we need to provide a domain in the packet if an only if it was provided by the user in the auth request
           if @request.auth.ntlm[2]
-            message_builder[:domain] = Net::NTLM::encode_utf16le(@request.auth.ntlm[2].upcase)
+            message_builder[:domain] = Net::NTLM::EncodeUtil.encode_utf16le(@request.auth.ntlm[2].upcase)
           else
             message_builder[:domain] = ''
           end
 
           # we should also provide the workstation name, currently the rubyntlm provider does not automatically
           # set the workstation name
-          message_builder[:workstation] = Net::NTLM::encode_utf16le(Socket.gethostname)
+          message_builder[:workstation] = Net::NTLM::EncodeUtil.encode_utf16le(Socket.gethostname)
           
           ntlm_response = ntlm_message.response(message_builder ,
                                                  {:ntlmv2 => true})


### PR DESCRIPTION
Net::NTLM::EncodeUtil is not defined in the httpi gem.
This commit fixes a crash when attempting to make NTLM authentication.
