### PR TITLE
make compatible with rubyntlm 0.3

### DIFF
--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -110,14 +110,10 @@ module HTTPI
 
           # we need to provide a domain in the packet if an only if it was provided by the user in the auth request
           if @request.auth.ntlm[2]
-            message_builder[:domain] = Net::NTLM::EncodeUtil.encode_utf16le(@request.auth.ntlm[2].upcase)
+            message_builder[:domain] = @request.auth.ntlm[2].upcase
           else
             message_builder[:domain] = ''
           end
-
-          # we should also provide the workstation name, currently the rubyntlm provider does not automatically
-          # set the workstation name
-          message_builder[:workstation] = Net::NTLM::EncodeUtil.encode_utf16le(Socket.gethostname)
           
           ntlm_response = ntlm_message.response(message_builder ,
                                                  {:ntlmv2 => true})


### PR DESCRIPTION
httpi has 'rubyntlm',  '~> 0.3.2' in its gem file, but there are two problems with using that version.

1) httpi is encoding the domain (using encode_utf16le) if a domain is passed into for ntlm authentication. When its passed to rubyntlm, it too encodes this parameter, using the same method. This double encoding does not work when passed in for authentication to a server, only the first letter is decoded. The username and password are not encoded by httpi which is correct. I simply stopped httpi from encoding the domain, as it doesn't need to.

2) httpi is attempting to pass in the 'workstation' by passing it in to the first parameter of rubyntlm's response method (arg), when its actually looking for it in the second parameter (opt). Luckily rubyntlm is also doing a workstation lookup, using the same Socket method, so the one in httpi is pointless. The comment in the httpi code indicates it was attempting to set it because rubyntlm wasn't doing it. Due to this comment, and it setting it in the wrong place it must have been referring to a previous version.

I believe this fixes the following issue: https://github.com/savonrb/httpi/issues/102

Tests pass with this change.

Thanks
