### PR TITLE
ssl_version was only being set if SSL auth settings were present

### DIFF
--- a/lib/httpi/adapter/httpclient.rb
+++ b/lib/httpi/adapter/httpclient.rb
@@ -41,7 +41,7 @@ module HTTPI
         end
 
         setup_auth if @request.auth.http?
-        setup_ssl_auth if @request.auth.ssl?
+        setup_ssl_auth if @request.auth.ssl? || @request.ssl?
       end
 
       def basic_setup
@@ -57,15 +57,18 @@ module HTTPI
       def setup_ssl_auth
         ssl = @request.auth.ssl
 
-        if ssl.ca_cert_file && ssl.verify_mode != :none
-          @client.ssl_config.add_trust_ca(ssl.ca_cert_file)
+        if @request.auth.ssl?
+          if ssl.ca_cert_file && ssl.verify_mode != :none
+            @client.ssl_config.add_trust_ca(ssl.ca_cert_file)
+          end
+
+          # Send client-side certificate regardless of state of SSL verify mode
+          @client.ssl_config.client_cert = ssl.cert
+          @client.ssl_config.client_key = ssl.cert_key
+
+          @client.ssl_config.verify_mode = ssl.openssl_verify_mode
         end
 
-        # Send client-side certificate regardless of state of SSL verify mode
-        @client.ssl_config.client_cert = ssl.cert
-        @client.ssl_config.client_key = ssl.cert_key
-
-        @client.ssl_config.verify_mode = ssl.openssl_verify_mode
         @client.ssl_config.ssl_version = ssl.ssl_version.to_s if ssl.ssl_version
       end
 

--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -80,7 +80,7 @@ module HTTPI
 
       def setup
         setup_client
-        setup_ssl_auth if @request.auth.ssl?
+        setup_ssl_auth if @request.auth.ssl? || @request.ssl?
       end
 
       def negotiate_ntlm_auth(http, &requester)
@@ -145,15 +145,18 @@ module HTTPI
       def setup_ssl_auth
         ssl = @request.auth.ssl
 
-        unless ssl.verify_mode == :none
-          @client.ca_file = ssl.ca_cert_file if ssl.ca_cert_file
+        if @request.auth.ssl?
+          unless ssl.verify_mode == :none
+            @client.ca_file = ssl.ca_cert_file if ssl.ca_cert_file
+          end
+
+          # Send client-side certificate regardless of state of SSL verify mode
+          @client.key = ssl.cert_key
+          @client.cert = ssl.cert
+
+          @client.verify_mode = ssl.openssl_verify_mode
         end
 
-        # Send client-side certificate regardless of state of SSL verify mode
-        @client.key = ssl.cert_key
-        @client.cert = ssl.cert
-
-        @client.verify_mode = ssl.openssl_verify_mode
         @client.ssl_version = ssl.ssl_version if ssl.ssl_version
       end
 

--- a/spec/httpi/adapter/curb_spec.rb
+++ b/spec/httpi/adapter/curb_spec.rb
@@ -218,6 +218,42 @@ unless RUBY_PLATFORM =~ /java/
         end
       end
 
+      context "(for SSL without auth)" do
+        let(:request) do
+          request = HTTPI::Request.new("http://example.com")
+          request.ssl = true
+          request
+        end
+
+        context 'sets ssl_version' do
+          it 'defaults to nil when no ssl_version is specified' do
+            curb.expects(:ssl_version=).with(nil)
+            adapter.request(:get)
+          end
+
+          it 'to 1 when ssl_version is specified as TLSv1' do
+            request.auth.ssl.ssl_version = :TLSv1
+            curb.expects(:ssl_version=).with(1)
+
+            adapter.request(:get)
+          end
+
+          it 'to 2 when ssl_version is specified as SSLv2' do
+            request.auth.ssl.ssl_version = :SSLv2
+            curb.expects(:ssl_version=).with(2)
+
+            adapter.request(:get)
+          end
+
+          it 'to 3 when ssl_version is specified as SSLv3' do
+            request.auth.ssl.ssl_version = :SSLv3
+            curb.expects(:ssl_version=).with(3)
+
+            adapter.request(:get)
+          end
+        end
+      end
+
       context "(for SSL client auth)" do
         let(:request) do
           request = HTTPI::Request.new("http://example.com")
@@ -260,34 +296,6 @@ unless RUBY_PLATFORM =~ /java/
           curb.expects(:cacert=).with(request.auth.ssl.ca_cert_file)
 
           adapter.request(:get)
-        end
-
-        context 'sets ssl_version' do
-          it 'defaults to nil when no ssl_version is specified' do
-            curb.expects(:ssl_version=).with(nil)
-            adapter.request(:get)
-          end
-
-          it 'to 1 when ssl_version is specified as TLSv1' do
-            request.auth.ssl.ssl_version = :TLSv1
-            curb.expects(:ssl_version=).with(1)
-
-            adapter.request(:get)
-          end
-
-          it 'to 2 when ssl_version is specified as SSLv2' do
-            request.auth.ssl.ssl_version = :SSLv2
-            curb.expects(:ssl_version=).with(2)
-
-            adapter.request(:get)
-          end
-
-          it 'to 3 when ssl_version is specified as SSLv3' do
-            request.auth.ssl.ssl_version = :SSLv3
-            curb.expects(:ssl_version=).with(3)
-
-            adapter.request(:get)
-          end
         end
       end
     end

--- a/spec/httpi/adapter/httpclient_spec.rb
+++ b/spec/httpi/adapter/httpclient_spec.rb
@@ -107,6 +107,19 @@ describe HTTPI::Adapter::HTTPClient do
       end
     end
 
+    context "(for SSL without auth)" do
+      before do
+        request.ssl = true
+      end
+
+      it 'should set the ssl_version if specified' do
+        request.auth.ssl.ssl_version = :SSLv3
+        ssl_config.expects(:ssl_version=).with('SSLv3')
+
+        adapter.request(:get)
+      end
+    end
+
     context "(for SSL client auth)" do
       before do
         request.auth.ssl.cert_key_file = "spec/fixtures/client_key.pem"


### PR DESCRIPTION
Pull request for https://github.com/savonrb/httpi/issues/106 .

I have changed the conditions that surround that method so that the SSL version is set regardless of SSL auth settings. I'm not entirely happy with the way that the SSL version stuff is wrapped up in the `@request.auth` object, and the use of both `@request.auth.ssl?` and `@request.ssl?` but I wanted to create a minimal pull request that solved the problem.

I had to rejig the test-suite so that the SSL version tests weren't encapsulated in a context where the SSL auth settings were getting configured. New tests now pass with my modifications to the following adapters:
- net_http
- httpclient
- curb

I'm not a user of RSpec, but I think I managed to write effective tests by inferring from what was already there, however the net_http adapter spec is quite different to the others and I wasn't able to write a test for that adapter, but have applied the same fix.

em_http and rack don't seem to support ssl (or at least ssl client auth? not sure ...) so I didn't change them. excon has a bunch of ssl stuff but no mention of ssl_version ..
