### PR TITLE
Check rubyntlm version in a 0.4.0+ compatible way

### DIFF
--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -7,6 +7,7 @@ require 'socket'
 
 begin
   require 'net/ntlm'
+  require 'net/ntlm/version' unless Net::NTLM.const_defined?(:VERSION)
   unless Net::NTLM::VERSION::STRING >= '0.3.2'
     raise ArgumentError('Invalid version of rubyntlm. Please use v0.3.2+.')
   end


### PR DESCRIPTION
Fixes errors caused by using `rubyntlm` v0.4.0. Continues to work with v0.3.2+.
