### PR TITLE
Fix NoMethodError when not using NTLM

### DIFF
--- a/lib/httpi.rb
+++ b/lib/httpi.rb
@@ -1,6 +1,5 @@
-require "logger"
-
 require "httpi/version"
+require "httpi/logger"
 require "httpi/request"
 
 require "httpi/adapter/httpclient"
@@ -145,42 +144,6 @@ module HTTPI
       Adapter.use = adapter
     end
 
-    # Sets whether to log HTTP requests.
-    attr_writer :log
-
-    # Returns whether to log HTTP requests. Defaults to +true+.
-    def log?
-      @log != false
-    end
-
-    # Sets the logger to use.
-    attr_writer :logger
-
-    # Returns the logger. Defaults to an instance of +Logger+ writing to STDOUT.
-    def logger
-      @logger ||= ::Logger.new($stdout)
-    end
-
-    # Sets the log level.
-    attr_writer :log_level
-
-    # Returns the log level. Defaults to :debug.
-    def log_level
-      @log_level ||= DEFAULT_LOG_LEVEL
-    end
-
-    # Logs a given +message+.
-    def log(message)
-      logger.send(log_level, message) if log?
-    end
-
-    # Reset the default config.
-    def reset_config!
-      @log = nil
-      @logger = nil
-      @log_level = nil
-    end
-
     private
 
     def request_and_adapter_from(args)
@@ -190,10 +153,6 @@ module HTTPI
 
     def load_adapter(adapter, request)
       Adapter.load(adapter).new(request)
-    end
-
-    def log_request(method, request, adapter)
-      log("HTTPI #{method.to_s.upcase} request to #{request.url.host} (#{adapter})")
     end
 
   end

--- a/lib/httpi/logger.rb
+++ b/lib/httpi/logger.rb
@@ -1,0 +1,50 @@
+require "logger"
+
+module HTTPI
+
+  class << self
+
+    # Sets whether to log HTTP requests.
+    attr_writer :log
+
+    # Returns whether to log HTTP requests. Defaults to +true+.
+    def log?
+      @log != false
+    end
+
+    # Sets the logger to use.
+    attr_writer :logger
+
+    # Returns the logger. Defaults to an instance of +Logger+ writing to STDOUT.
+    def logger
+      @logger ||= ::Logger.new($stdout)
+    end
+
+    # Sets the log level.
+    attr_writer :log_level
+
+    # Returns the log level. Defaults to :debug.
+    def log_level
+      @log_level ||= DEFAULT_LOG_LEVEL
+    end
+
+    # Logs a given +message+.
+    def log(message)
+      logger.send(log_level, message) if log?
+    end
+
+    # Reset the default config.
+    def reset_config!
+      @log = nil
+      @logger = nil
+      @log_level = nil
+    end
+
+    protected
+
+    def log_request(method, request, adapter)
+      log("HTTPI #{method.to_s.upcase} request to #{request.url.host} (#{adapter})")
+    end
+
+  end
+end


### PR DESCRIPTION
Issue #115.
This fix makes HTTPI.logger available, during require of adapters.
