### PR TITLE
Fixes #67 - Follow HTTP redirects.

### DIFF
--- a/lib/httpi.rb
+++ b/lib/httpi.rb
@@ -136,7 +136,15 @@ module HTTPI
       yield adapter_class.client if block_given?
       log_request(method, request, Adapter.identify(adapter_class.class))
 
-      adapter_class.request(method)
+      response = adapter_class.request(method)
+
+      if response and response.code == 302 and request.follow_redirect?
+        log('Following redirect...')
+        request.url = response.headers['location']
+        return request(method, request, adapter)
+      end
+
+      response
     end
 
     # Shortcut for setting the default adapter to use.

--- a/lib/httpi/request.rb
+++ b/lib/httpi/request.rb
@@ -11,7 +11,7 @@ module HTTPI
   class Request
 
     # Available attribute writers.
-    ATTRIBUTES = [:url, :proxy, :headers, :body, :open_timeout, :read_timeout]
+    ATTRIBUTES = [:url, :proxy, :headers, :body, :open_timeout, :read_timeout, :follow_redirect]
 
     # Accepts a Hash of +args+ to mass assign attributes and authentication credentials.
     def initialize(args = {})
@@ -121,6 +121,13 @@ module HTTPI
     # Expects a Hash of +args+ to assign.
     def mass_assign(args)
       ATTRIBUTES.each { |key| send("#{key}=", args[key]) if args[key] }
+    end
+
+    attr_writer :follow_redirect
+
+    # Returns whether or not redirects should be followed - defaults to false if not set.
+    def follow_redirect?
+      @follow_redirect ||= false
     end
 
     private

--- a/spec/httpi/httpi_spec.rb
+++ b/spec/httpi/httpi_spec.rb
@@ -195,9 +195,23 @@ describe HTTPI do
   end
 
   describe ".request" do
+    let(:request) { HTTPI::Request.new('http://example.com') }
+
     it "allows custom HTTP methods" do
-      request = HTTPI::Request.new("http://example.com")
       httpclient.any_instance.expects(:request).with(:custom)
+
+      client.request(:custom, request, :httpclient)
+    end
+
+    it 'follows redirects' do
+      request.follow_redirect = true
+      redirect_location = 'http://foo.bar'
+
+      redirect = HTTPI::Response.new(302, {'location' => redirect_location}, 'Moved')
+      response = HTTPI::Response.new(200, {}, 'success')
+
+      httpclient.any_instance.expects(:request).twice.with(:custom).returns(redirect, response)
+      request.expects(:url=).with(redirect_location)
 
       client.request(:custom, request, :httpclient)
     end
@@ -249,7 +263,7 @@ describe HTTPI do
 
     describe ".log" do
       it "defaults to true" do
-        expect(HTTPI.log?).to be_true
+        expect(HTTPI.log?).to be_truthy
       end
     end
 

--- a/spec/httpi/request_spec.rb
+++ b/spec/httpi/request_spec.rb
@@ -206,11 +206,22 @@ describe HTTPI::Request do
   describe "#auth?" do
     it "returns true when auth credentials are specified" do
       request.auth.basic "username", "password"
-      expect(request.auth?).to be_true
+      expect(request.auth?).to be_truthy
     end
 
     it "returns false otherwise" do
-      expect(request.auth?).to be_false
+      expect(request.auth?).to be_falsey
+    end
+  end
+
+  describe '#follow_redirect?' do
+    it 'returns true when follow_redirect is set to true' do
+      request.follow_redirect = true
+      expect(request.follow_redirect?).to be_truthy
+    end
+
+    it 'returns false by default' do
+      expect(request.follow_redirect?).to be_falsey
     end
   end
 


### PR DESCRIPTION
Follow HTTP redirects.
Add tests.
Fix deprecation warnings (be_true and be_false).
