### PR TITLE
Support for other SSL certificate keys, not only RSA

### DIFF
--- a/lib/httpi/auth/ssl.rb
+++ b/lib/httpi/auth/ssl.rb
@@ -92,9 +92,9 @@ module HTTPI
       # Sets the +OpenSSL+ ca certificate.
       attr_writer :ca_cert
 
-      # Returns an <tt>OpenSSL::PKey::RSA</tt> for the +cert_key_file+.
+      # Returns an <tt>OpenSSL::PKey</tt> subclass (usually <tt>OpenSSL::PKey::RSA</tt>) for the +cert_key_file+.
       def cert_key
-        @cert_key ||= (OpenSSL::PKey::RSA.new(File.read(cert_key_file), cert_key_password) if cert_key_file)
+        @cert_key ||= (OpenSSL::PKey.read(File.read(cert_key_file), cert_key_password) if cert_key_file)
       end
 
       # Sets the +OpenSSL+ certificate key.


### PR DESCRIPTION
There is many key types in the wild: [RSA, DSA, EC, DH](http://ruby-doc.org/stdlib-2.0/libdoc/openssl/rdoc/OpenSSL/PKey.html).

We're currently working with service, that requires HTTPS with GOST encryption and client certificate authentication. So, we need to specify GOST R 34.10-2001 certificate and keys, but HTTPI currently allows to use only RSA keys.

GOST R 34.10-2001 are treated as EC keys with [our current patches for Ruby](https://bugs.ruby-lang.org/issues/9830), but it may change in future.

This PR fixes this by letting Ruby itself decide what the type provided key is (it doing this here, called from [`OpenSSL::PKey.read`](http://ruby-doc.org/stdlib-2.0/libdoc/openssl/rdoc/OpenSSL/PKey.html): https://github.com/ruby/ruby/blob/trunk/ext/openssl/ossl_pkey.c#L76)

P.S> Please, also merge savonrb/savon#588, we need this functionality to use from savon.
