### PR TITLE
Don't warn about missing rubyntlm gem if it is optional

### DIFF
--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -85,7 +85,7 @@ module HTTPI
 
       def negotiate_ntlm_auth(http, &requester)
         unless Net.const_defined?(:NTLM)
-          HTTPI.logger.fatal('Cannot negotiate ntlm auth if net/ntlm is not present. Perhaps the net/ntlm gem is not installed?')
+          raise NotSupportedError, 'Net::NTLM is not available. Install via gem install rubyntlm.'
         end
 
         # first figure out if we should use NTLM or Negotiate

--- a/spec/httpi/adapter/net_http_spec.rb
+++ b/spec/httpi/adapter/net_http_spec.rb
@@ -76,15 +76,14 @@ describe HTTPI::Adapter::NetHTTP do
       expect(response.body).to eq("ntlm-auth")
     end
 
-    it 'fatal logs when net/ntlm is not available, but ntlm authentication was requested' do
+    it 'does not support ntlm authentication when Net::NTLM is not available' do
       Net.expects(:const_defined?).with(:NTLM).returns false
 
       request = HTTPI::Request.new(@server.url + 'ntlm-auth')
       request.auth.ntlm("testing", "failures")
-      HTTPI.logger.expects(:fatal)
 
-      response = HTTPI.get(request, adapter)
-      expect(response.body).to eq("ntlm-auth")
+      expect { HTTPI.get(request, adapter) }.
+        to raise_error(HTTPI::NotSupportedError, /Net::NTLM is not available/)
     end
   end
 


### PR DESCRIPTION
And raise `NotSupportedError` when trying to authenticate with NTLM and the gem is missing.

If you removed/commented the rubyntlm gem from the gemspec the test about the missing gem would fail which is strange, like this only the one that actually needs the gem fails. This makes a lot more sense to me.
