### PR TITLE
Query builder, an option to flat or nested queries

### DIFF
--- a/lib/httpi/query_builder.rb
+++ b/lib/httpi/query_builder.rb
@@ -1,0 +1,47 @@
+module HTTPI
+  module QueryBuilder
+
+    class Flat
+
+      # Returns a +query+ string given a +Hash+.
+      # Example:
+      #
+      #   build({names => ['Bruno', 'Samantha', 'Alexandre']})
+      #   # => "names=Bruno&names=Samantha&names=Alexandre"
+      def self.build(query)
+        Rack::Utils.build_query(query)
+      end
+
+    end
+
+    class Nested
+
+      # Returns a +query+ string given a +Hash+.
+      # Example:
+      #
+      #   build({names => ['Bruno', 'Samantha', 'Alexandre']})
+      #   # => "names[]=Bruno&names[]=Samantha&names[]=Alexandre"
+      def self.build(query)
+        stringfied_query = stringify_hash_values(query)
+        Rack::Utils.build_nested_query(stringfied_query)
+      end
+
+      private
+
+      # Changes Hash values into Strings
+      def self.stringify_hash_values(query)
+        query.each do |param, value|
+          if value.kind_of?(Hash)
+            query[param] = stringify_hash_values(value)
+          elsif value.kind_of?(Array)
+            query[param] = value.map(&:to_s)
+          else
+            query[param] = value.to_s
+          end
+        end
+      end
+
+    end
+
+  end
+end

--- a/lib/httpi/request.rb
+++ b/lib/httpi/request.rb
@@ -145,20 +145,8 @@ module HTTPI
 
     # Returns a +query+ string given a +Hash+
     def build_query_from_hash(query)
-      HTTPI.use_nested_query ?  Rack::Utils.build_nested_query(stringify_hash_values(query)) : Rack::Utils.build_query(query)
+      HTTPI.query_builder.build(query)
     end
 
-    # Changes Hash values into Strings
-    def stringify_hash_values(query)
-      query.each do |param, value|
-        if value.kind_of?(Hash)
-          query[param] = stringify_hash_values(value)
-        elsif value.kind_of?(Array)
-          query[param] = value.map(&:to_s)
-        else
-          query[param] = value.to_s
-        end
-      end
-    end
   end
 end

--- a/spec/httpi/httpi_spec.rb
+++ b/spec/httpi/httpi_spec.rb
@@ -34,6 +34,33 @@ describe HTTPI do
     end
   end
 
+  describe ".query_builder" do
+    it "gets flat builder by default" do
+      expect(client.query_builder).to eq(HTTPI::QueryBuilder::Flat)
+    end
+    context "setter" do
+      after { client.query_builder = HTTPI::QueryBuilder::Flat }
+      it "looks up for class if symbol" do
+        client.query_builder = :nested
+        expect(client.query_builder).to eq(HTTPI::QueryBuilder::Nested)
+      end
+      it "validates if symbol is a valid option" do
+        expect do
+          client.query_builder = :xxx
+        end.to raise_error(ArgumentError)
+      end
+      it "validates if value respond to build" do
+        expect do
+          client.query_builder = nil
+        end.to raise_error(ArgumentError)
+      end
+      it "accepts valid class" do
+        client.query_builder = HTTPI::QueryBuilder::Nested
+        expect(client.query_builder).to eq(HTTPI::QueryBuilder::Nested)
+      end
+    end
+  end
+
   describe ".get(request)" do
     it "executes a GET request using the default adapter" do
       request = HTTPI::Request.new("http://example.com")


### PR DESCRIPTION
`query_builder` attribute it's a flexible way to change the behavior when building request's query or body from Hashes. Available options: `[:flat, :nested]`

Example:

```
  HTTPI.query_builder # => HTTPI::QueryBuilder::Flat (by default)
  HTTPI.query_builder = :nested # => HTTPI::QueryBuilder::Nested
```

You can also customize and set your own query builder. Example:

```
  class CustomBuilder
    def self.build(query)
      # query is a Hash and you have to return a String
    end
  end
  HTTPI.query_builder = CustomBuilder
```

Thanks to @bvicenzo PR #125 
This PR also fixes #122 
