### PR TITLE
Add 'query' to available attribute writers so it can be set with 'new'

### DIFF
--- a/lib/httpi/request.rb
+++ b/lib/httpi/request.rb
@@ -11,7 +11,7 @@ module HTTPI
   class Request
 
     # Available attribute writers.
-    ATTRIBUTES = [:url, :proxy, :headers, :body, :open_timeout, :read_timeout, :follow_redirect]
+    ATTRIBUTES = [:url, :proxy, :headers, :body, :open_timeout, :read_timeout, :follow_redirect, :query]
 
     # Accepts a Hash of +args+ to mass assign attributes and authentication credentials.
     def initialize(args = {})

--- a/spec/httpi/request_spec.rb
+++ b/spec/httpi/request_spec.rb
@@ -11,9 +11,10 @@ describe HTTPI::Request do
     end
 
     it "accepts a Hash of accessors to set" do
-      request = HTTPI::Request.new :url => "http://example.com", :open_timeout => 30
-      expect(request.url).to eq(URI("http://example.com"))
+      request = HTTPI::Request.new :url => "http://example.com", :open_timeout => 30, :query => { key: "value" }
+      expect(request.url).to eq(URI("http://example.com?key=value"))
       expect(request.open_timeout).to eq(30)
+      expect(request.query).to eq("key=value")
     end
   end
 


### PR DESCRIPTION
At the the moment, `HTTPI::Request.new` ignores `query` as a parameter.

``` ruby
HTTPI::Request.new(url: "http://example.org", query: { foo: "bar" })
=> #<HTTPI::Request:0x02b05598 @url=#<URI::HTTP:0x02b05188 URL:http://example.org>>
```

Expected behaviour would be

``` ruby
HTTPI::Request.new(url: "http://example.org", query: { foo: "bar" })
=> #<HTTPI::Request:0x0579cbd8 @url=#<URI::HTTP:0x0579c890 URL:http://example.org?foo=bar>>
```

This PR adds `query` to `Request::Attributes` so that it is called in `Request#mass_assign`.
