### PR TITLE
fix call Curb client "SSL peer certificate or SSH remote key was not OK" bug

### DIFF
--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -98,7 +98,9 @@ module HTTPI
         ssl = @request.auth.ssl
 
         if @request.auth.ssl?
-          unless ssl.verify_mode == :none
+          if ssl.verify_mode == :none
+            @client.ssl_verify_host = 0
+          else
             @client.cacert = ssl.ca_cert_file if ssl.ca_cert_file
             @client.certtype = ssl.cert_type.to_s.upcase
           end


### PR DESCRIPTION
same for Savon & source : https://github.com/taf2/curb/issues/212