### PR TITLE
ensure that header exists before accessing it

### DIFF
--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -92,9 +92,9 @@ module HTTPI
 
         # first figure out if we should use NTLM or Negotiate
         nego_auth_response = respond_with(requester.call(http, request_client(:head)))
-        if nego_auth_response.headers['www-authenticate'].include? 'Negotiate'
+        if nego_auth_response.headers['www-authenticate'] && nego_auth_response.headers['www-authenticate'].include?('Negotiate')
           auth_method = 'Negotiate'
-        elsif nego_auth_response.headers['www-authenticate'].include? 'NTLM'
+        elsif nego_auth_response.headers['www-authenticate'] && nego_auth_response.headers['www-authenticate'].include?('NTLM')
           auth_method = 'NTLM'
         else
           auth_method = 'NTLM'

--- a/spec/httpi/adapter/net_http_spec.rb
+++ b/spec/httpi/adapter/net_http_spec.rb
@@ -85,6 +85,17 @@ describe HTTPI::Adapter::NetHTTP do
       expect { HTTPI.get(request, adapter) }.
         to raise_error(HTTPI::NotSupportedError, /Net::NTLM is not available/)
     end
+
+    it "does not crash when authenticate header is missing (on second request)" do
+      request = HTTPI::Request.new(@server.url + 'ntlm-auth')
+      request.auth.ntlm("tester", "vReqSoafRe5O")
+
+      expect { HTTPI.get(request, adapter) }.
+        to_not raise_error
+
+      expect { HTTPI.get(request, adapter) }.
+        to_not raise_error
+    end
   end
 
   # it does not support digest auth


### PR DESCRIPTION
I use this gem through the savon gem. In my project I noticed a small bug:

If the first (savon) call fails (e.g. because of a typo in the WSDL URL) the next call to the same savon object crashes with this callstack:

```
undefined method `include?' for nil:NilClass
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/httpi-2.4.0/lib/httpi/adapter/net_http.rb:103:in `negotiate_ntlm_auth'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/httpi-2.4.0/lib/httpi/adapter/net_http.rb:80:in `block in do_request'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/httpi-2.4.0/lib/httpi/adapter/net_http.rb:79:in `do_request'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/httpi-2.4.0/lib/httpi/adapter/net_http.rb:34:in `request'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/httpi-2.4.0/lib/httpi.rb:160:in `request'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/httpi-2.4.0/lib/httpi.rb:126:in `get'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/wasabi-3.5.0/lib/wasabi/resolver.rb:43:in `load_from_remote'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/wasabi-3.5.0/lib/wasabi/resolver.rb:33:in `resolve'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/wasabi-3.5.0/lib/wasabi/document.rb:142:in `xml'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/wasabi-3.5.0/lib/wasabi/document.rb:160:in `parse'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/wasabi-3.5.0/lib/wasabi/document.rb:147:in `parser'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/wasabi-3.5.0/lib/wasabi/document.rb:64:in `soap_actions'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/savon-2.11.1/lib/savon/operation.rb:23:in `ensure_exists!'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/savon-2.11.1/lib/savon/operation.rb:15:in `create'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/savon-2.11.1/lib/savon/client.rb:32:in `operation'
/home/swelther/.rvm/gems/ruby-2.0.0-p451/gems/savon-2.11.1/lib/savon/client.rb:36:in `call'
```

This PR adds a check if the header is really present and resolves my bug from above.