### PR TITLE
Enable socks proxy server specification

### DIFF
--- a/httpi.gemspec
+++ b/httpi.gemspec
@@ -17,12 +17,14 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency 'rack'
+  s.add_dependency 'socksify'
 
   s.add_development_dependency 'rubyntlm', '~> 0.3.2'
   s.add_development_dependency 'rake',     '~> 10.0'
   s.add_development_dependency 'rspec',    '~> 2.14'
   s.add_development_dependency 'mocha',    '~> 0.13'
   s.add_development_dependency 'puma',     '~> 2.3.2'
+  s.add_development_dependency 'webmock'
 
   s.files = `git ls-files`.split("\n")
   s.require_path = 'lib'

--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -4,6 +4,8 @@ require "httpi/adapter/base"
 require "httpi/response"
 require 'kconv'
 require 'socket'
+require "socksify"
+require 'socksify/http'
 
 module HTTPI
   module Adapter
@@ -67,7 +69,11 @@ module HTTPI
 
       def create_client
         proxy_url = @request.proxy || URI("")
-        proxy = Net::HTTP::Proxy(proxy_url.host, proxy_url.port, proxy_url.user, proxy_url.password)
+        if URI(proxy_url).scheme == 'socks'
+          proxy =Net::HTTP.SOCKSProxy(proxy_url.host, proxy_url.port)
+        else
+          proxy = Net::HTTP::Proxy(proxy_url.host, proxy_url.port, proxy_url.user, proxy_url.password)
+        end
         proxy.new(@request.url.host, @request.url.port)
       end
 

--- a/lib/httpi/request.rb
+++ b/lib/httpi/request.rb
@@ -139,7 +139,7 @@ module HTTPI
 
     # Expects a +url+, validates its validity and returns a +URI+ object.
     def normalize_url!(url)
-      raise ArgumentError, "Invalid URL: #{url}" unless url.to_s =~ /^http/
+      raise ArgumentError, "Invalid URL: #{url}" unless url.to_s =~ /^http|socks/
       url.kind_of?(URI) ? url : URI(url)
     end
 

--- a/spec/httpi/adapter/net_http_spec.rb
+++ b/spec/httpi/adapter/net_http_spec.rb
@@ -14,6 +14,22 @@ describe HTTPI::Adapter::NetHTTP do
       @server.stop
     end
 
+    context 'when socks is specified' do
+
+      let(:socks_client) { mock('socks_client') }
+      let(:request){HTTPI::Request.new(@server.url)}
+
+      it 'uses Net::HTTP.SOCKSProxy as client' do
+        socks_client.expects(:new).with(URI(@server.url).host, URI(@server.url).port).returns(:socks_client_instance)
+        Net::HTTP.expects(:SOCKSProxy).with('localhost', 8080).returns socks_client
+
+        request.proxy = 'socks://localhost:8080'
+        adapter = HTTPI::Adapter::NetHTTP.new(request)
+
+        expect(adapter.client).to eq(:socks_client_instance)
+      end
+    end
+
     it "sends and receives HTTP headers" do
       request = HTTPI::Request.new(@server.url + "x-header")
       request.headers["X-Header"] = "HTTPI"

--- a/spec/httpi/request_spec.rb
+++ b/spec/httpi/request_spec.rb
@@ -108,6 +108,11 @@ describe HTTPI::Request do
       expect(request.proxy).to eq(URI("http://proxy.example.com"))
     end
 
+    it 'also accepts the socks URL to use as a String' do
+      request.proxy ="socks://socks.example.com"
+      expect(request.proxy).to eq(URI("socks://socks.example.com"))
+    end
+
     it "also accepts a URI object" do
       request.proxy = URI("http://proxy.example.com")
       expect(request.proxy).to eq(URI("http://proxy.example.com"))


### PR DESCRIPTION
This will let a user to specify a socks proxy server in order to perform a request via it