### PR TITLE
fixing excon adapter to pass client_cert and key as strings instead of objects

### DIFF
--- a/lib/httpi/adapter/excon.rb
+++ b/lib/httpi/adapter/excon.rb
@@ -65,8 +65,8 @@ module HTTPI
         when :peer
           opts[:ssl_verify_peer] = true
           opts[:ssl_ca_file] = ssl.ca_cert_file if ssl.ca_cert_file
-          opts[:client_cert] = ssl.cert     if ssl.cert
-          opts[:client_key]  = ssl.cert_key if ssl.cert_key
+          opts[:certificate] = ssl.cert.to_pem     if ssl.cert
+          opts[:private_key] = ssl.cert_key.to_pem if ssl.cert_key
         when :none
           opts[:ssl_verify_peer] = false
         end

--- a/spec/httpi/adapter/excon_spec.rb
+++ b/spec/httpi/adapter/excon_spec.rb
@@ -90,9 +90,30 @@ describe HTTPI::Adapter::Excon do
       end
 
       # it does not raise when no certificate was set up
-      it "works when set up properly" do
+      it "works when no client cert is specified" do
         request = HTTPI::Request.new(@server.url)
         request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
+
+        response = HTTPI.get(request, adapter)
+        expect(response.body).to eq("get")
+      end
+
+      it "works with client cert and key provided as file path" do
+        request = HTTPI::Request.new(@server.url)
+        request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
+        request.auth.ssl.cert_file = "spec/fixtures/client_cert.pem"
+        request.auth.ssl.cert_key_file = "spec/fixtures/client_key.pem"
+
+        response = HTTPI.get(request, adapter)
+        expect(response.body).to eq("get")
+      end
+
+      it "works with client cert and key set directly" do
+        request = HTTPI::Request.new(@server.url)
+        
+        request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
+        request.auth.ssl.cert = OpenSSL::X509::Certificate.new File.open("spec/fixtures/client_cert.pem").read
+        request.auth.ssl.cert_key = OpenSSL::PKey.read File.open("spec/fixtures/client_key.pem").read
 
         response = HTTPI.get(request, adapter)
         expect(response.body).to eq("get")


### PR DESCRIPTION
this is in reference to #161 