### PR TITLE
Extended net_http adapter ssl options with cert_store and ca_path

### DIFF
--- a/lib/httpi/auth/ssl.rb
+++ b/lib/httpi/auth/ssl.rb
@@ -31,6 +31,12 @@ module HTTPI
       # Accessor for the cacert file to validate SSL certificates.
       attr_accessor :ca_cert_file
 
+      # Accessor for the ca_path to validate SSL certificates.
+      attr_accessor :ca_cert_path
+
+      # ertificate store holds trusted CA certificates used to verify peer certificates.
+      attr_accessor :cert_store
+
       # Returns the cert type to validate SSL certificates PEM|DER.
       def cert_type
         @cert_type ||= :pem


### PR DESCRIPTION
Some people might find it useful to use ca_cert path and cert store, like in Faraday