### PR TITLE
fix some warnings

### DIFF
--- a/lib/httpi.rb
+++ b/lib/httpi.rb
@@ -103,7 +103,7 @@ module HTTPI
   class << self
 
     def query_builder
-      @query_builder || HTTPI::QueryBuilder::Flat
+      @query_builder ||= HTTPI::QueryBuilder::Flat
     end
 
     def query_builder=(builder)

--- a/lib/httpi/auth/ssl.rb
+++ b/lib/httpi/auth/ssl.rb
@@ -10,7 +10,7 @@ module HTTPI
 
       VERIFY_MODES = [:none, :peer, :fail_if_no_peer_cert, :client_once]
       CERT_TYPES = [:pem, :der]
-      SSL_VERSIONS = OpenSSL::SSL::SSLContext::METHODS.reject { |method| method.match /server|client/ }.sort.reverse
+      SSL_VERSIONS = OpenSSL::SSL::SSLContext::METHODS.reject { |method| method.match(/server|client/) }.sort.reverse
 
       # Returns whether SSL configuration is present.
       def present?
@@ -63,7 +63,7 @@ module HTTPI
 
       # Returns the SSL version number. Defaults to <tt>nil</tt> (auto-negotiate).
       def ssl_version
-        @ssl_version
+        @ssl_version ||= nil
       end
 
       # Sets the SSL version number. Expects one of <tt>HTTPI::Auth::SSL::SSL_VERSIONS</tt>.

--- a/lib/httpi/request.rb
+++ b/lib/httpi/request.rb
@@ -56,8 +56,7 @@ module HTTPI
 
     # Returns whether to use SSL.
     def ssl?
-      return @ssl unless @ssl.nil?
-      !!(url.to_s =~ /^https/)
+      @ssl ||= !!(url.to_s =~ /^https/)
     end
 
     # Sets whether to use SSL.
@@ -102,6 +101,7 @@ module HTTPI
     # Sets the block to be called while processing the response. The block
     # accepts a single parameter - the chunked response body.
     def on_body(&block)
+      @on_body ||= nil
       if block_given? then
         @on_body = block
       end

--- a/lib/httpi/response.rb
+++ b/lib/httpi/response.rb
@@ -44,12 +44,14 @@ module HTTPI
 
     # Returns any DIME attachments.
     def attachments
+      @body ||= nil
       decode_body unless @body
       @attachments ||= []
     end
 
     # Returns the HTTP response body.
     def body
+      @body ||= nil
       decode_body unless @body
       @body
     end

--- a/spec/httpi/adapter/curb_spec.rb
+++ b/spec/httpi/adapter/curb_spec.rb
@@ -20,7 +20,7 @@ unless RUBY_PLATFORM =~ /java/
     it "supports ntlm authentication" do
       request = HTTPI::Request.new(@server.url + "ntlm-auth")
       adapter = HTTPI::Adapter::Curb.new(request)
-      
+
       request.auth.ntlm("tester", "vReqSoafRe5O")
       expect(adapter.request(:get).body).to eq("ntlm-auth")
     end
@@ -257,8 +257,8 @@ unless RUBY_PLATFORM =~ /java/
           end
 
           it 'to 2 when ssl_version is specified as SSLv2/SSLv23' do
-            version = OpenSSL::SSL::SSLContext::METHODS.reject { |method| method.match /server|client/ }
-            version = version.select { |method| method.to_s.match /SSLv2|SSLv23/ }.first
+            version = OpenSSL::SSL::SSLContext::METHODS.reject { |method| method.match(/server|client/) }
+            version = version.select { |method| method.to_s.match(/SSLv2|SSLv23/) }.first
             request.auth.ssl.ssl_version = version
             curb.expects(:ssl_version=).with(2)
 

--- a/spec/httpi/auth/ssl_spec.rb
+++ b/spec/httpi/auth/ssl_spec.rb
@@ -3,7 +3,7 @@ require "httpi/auth/ssl"
 
 describe HTTPI::Auth::SSL do
   before(:all) do
-    @ssl_versions = OpenSSL::SSL::SSLContext::METHODS.reject { |method| method.match /server|client/ }.sort.reverse
+    @ssl_versions = OpenSSL::SSL::SSLContext::METHODS.reject { |method| method.match(/server|client/) }.sort.reverse
   end
 
   describe "VERIFY_MODES" do


### PR DESCRIPTION
Running specs before the changes with `RUBYOPT=-w`:

```
Ruby Warnings resolved:

 162 lib/httpi/request.rb:108: warning: instance variable @on_body not initialized
 147 lib/httpi/request.rb:59: warning: instance variable @ssl not initialized
 100 lib/httpi/response.rb:53: warning: instance variable @body not initialized
  40 lib/httpi/auth/ssl.rb:66: warning: instance variable @ssl_version not initialized
   1 spec/httpi/auth/ssl_spec.rb:6: warning: ambiguous first argument; put parentheses or a space even after `/' operator
   1 spec/httpi/adapter/curb_spec.rb:261: warning: ambiguous first argument; put parentheses or a space even after `/' operator
   1 spec/httpi/adapter/curb_spec.rb:260: warning: ambiguous first argument; put parentheses or a space even after `/' operator
   1 lib/httpi/response.rb:47: warning: instance variable @body not initialized
   1 lib/httpi/auth/ssl.rb:13: warning: ambiguous first argument; put parentheses or a space even after `/' operator
   1 lib/httpi.rb:106: warning: instance variable @query_builder not initialized
```