### PR TITLE
adds missing support for cert password

### DIFF
--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -114,6 +114,7 @@ module HTTPI
           # Send client-side certificate regardless of state of SSL verify mode
           @client.cert_key = ssl.cert_key_file
           @client.cert = ssl.cert_file
+          @client.certpassword = ssl.cert_key_password
 
           @client.ssl_verify_peer = ssl.verify_mode == :peer
         end

--- a/spec/httpi/adapter/curb_spec.rb
+++ b/spec/httpi/adapter/curb_spec.rb
@@ -20,7 +20,7 @@ unless RUBY_PLATFORM =~ /java/
     it "supports ntlm authentication" do
       request = HTTPI::Request.new(@server.url + "ntlm-auth")
       adapter = HTTPI::Adapter::Curb.new(request)
-      
+
       request.auth.ntlm("tester", "vReqSoafRe5O")
       expect(adapter.request(:get).body).to eq("ntlm-auth")
     end
@@ -279,6 +279,7 @@ unless RUBY_PLATFORM =~ /java/
           request = HTTPI::Request.new("http://example.com")
           request.auth.ssl.cert_key_file = "spec/fixtures/client_key.pem"
           request.auth.ssl.cert_file = "spec/fixtures/client_cert.pem"
+          request.auth.ssl.cert_key_password = 'example'
           request
         end
 
@@ -287,6 +288,7 @@ unless RUBY_PLATFORM =~ /java/
           curb.expects(:ssl_verify_host=).with(0) # avoid "SSL peer certificate" error
           curb.expects(:cert_key=).with(request.auth.ssl.cert_key_file)
           curb.expects(:cert=).with(request.auth.ssl.cert_file)
+          curb.expects(:certpassword=).with(request.auth.ssl.cert_key_password)
 
           adapter.request(:get)
         end
@@ -294,6 +296,7 @@ unless RUBY_PLATFORM =~ /java/
         it "cert_key, cert and ssl_verify_peer should be set" do
           curb.expects(:cert_key=).with(request.auth.ssl.cert_key_file)
           curb.expects(:cert=).with(request.auth.ssl.cert_file)
+          curb.expects(:certpassword=).with(request.auth.ssl.cert_key_password)
           curb.expects(:ssl_verify_peer=).with(true)
           curb.expects(:certtype=).with(request.auth.ssl.cert_type.to_s.upcase)
 


### PR DESCRIPTION
The main Savon client can set the cert password but it does not get passed down to curb through the adapter. This means that if you have an encrypted key, it cannot be decrypted using the password that was used to encrypt it.

Without this fix, it will result in the application asking for the pass phrase and hanging on runtime.