### PR TITLE
Implement HTTPI::Auth::SSL#ciphers configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,14 @@ gem 'curb',                '~> 0.8',    :require => false, :platforms => :ruby
 gem 'em-http-request',                  :require => false, :platforms => [:ruby, :jruby]
 gem 'em-synchrony',                     :require => false, :platforms => [:ruby, :jruby]
 gem 'excon',               '~> 0.21',   :require => false, :platforms => [:ruby, :jruby]
-gem 'net-http-persistent', '~> 2.8',    :require => false
-gem 'http',                             :require => false
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1')
+  gem 'net-http-persistent', '~> 3.0',  :require => false
+else
+  gem 'net-http-persistent', '~> 2.8',  :require => false
+end
+gem 'http',                '~> 1.0.4',  :require => false
+gem 'addressable',         '~> 2.4.0'
+gem 'mime-types',          '~> 2.6.2'
 
 # coverage
 gem 'simplecov',                        :require => false

--- a/httpi.gemspec
+++ b/httpi.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rubyntlm', '~> 0.3.2'
   s.add_development_dependency 'rake',     '~> 10.0'
-  s.add_development_dependency 'rspec',    '~> 2.14'
+  s.add_development_dependency 'rspec',    '~> 3.5'
   s.add_development_dependency 'mocha',    '~> 0.13'
   s.add_development_dependency 'puma',     '~> 2.3.2'
   s.add_development_dependency 'webmock'

--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -115,6 +115,7 @@ module HTTPI
           @client.cert_key = ssl.cert_key_file
           @client.cert = ssl.cert_file
           @client.certpassword = ssl.cert_key_password
+          @client.set(:ssl_cipher_list, ssl.ciphers.join(':')) if ssl.ciphers
 
           @client.ssl_verify_peer = ssl.verify_mode == :peer
         end

--- a/lib/httpi/adapter/excon.rb
+++ b/lib/httpi/adapter/excon.rb
@@ -71,6 +71,7 @@ module HTTPI
           opts[:ssl_verify_peer] = false
         end
 
+        opts[:ciphers] = ssl.ciphers if ssl.ciphers
         opts[:ssl_version] = ssl.ssl_version if ssl.ssl_version
 
         opts

--- a/lib/httpi/adapter/http.rb
+++ b/lib/httpi/adapter/http.rb
@@ -59,6 +59,7 @@ module HTTPI
           context.key         = @request.auth.ssl.cert_key
           context.ssl_version = @request.auth.ssl.ssl_version if @request.auth.ssl.ssl_version != nil
           context.verify_mode = @request.auth.ssl.openssl_verify_mode
+          context.ciphers     = @request.auth.ssl.ciphers if @request.auth.ssl.ciphers
 
           client = ::HTTP::Client.new(:ssl_context => context)
         else

--- a/lib/httpi/adapter/httpclient.rb
+++ b/lib/httpi/adapter/httpclient.rb
@@ -72,6 +72,7 @@ module HTTPI
           # Send client-side certificate regardless of state of SSL verify mode
           @client.ssl_config.client_cert = ssl.cert
           @client.ssl_config.client_key = ssl.cert_key
+          @client.ssl_config.ciphers = ssl.ciphers if ssl.ciphers
 
           @client.ssl_config.verify_mode = ssl.openssl_verify_mode
         end

--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -166,6 +166,7 @@ module HTTPI
           # Send client-side certificate regardless of state of SSL verify mode
           @client.key = ssl.cert_key
           @client.cert = ssl.cert
+          @client.ciphers = ssl.ciphers if ssl.ciphers
 
           @client.verify_mode = ssl.openssl_verify_mode
         end

--- a/lib/httpi/adapter/net_http_persistent.rb
+++ b/lib/httpi/adapter/net_http_persistent.rb
@@ -12,7 +12,11 @@ module HTTPI
       private
 
       def create_client
-        Net::HTTP::Persistent.new thread_key
+        if Gem::Version.new(Net::HTTP::Persistent::VERSION) < Gem::Version.new('3.0.0')
+          Net::HTTP::Persistent.new thread_key
+        else
+          Net::HTTP::Persistent.new name: thread_key
+        end
       end
 
       def perform(http, http_request, &on_body)

--- a/lib/httpi/auth/ssl.rb
+++ b/lib/httpi/auth/ssl.rb
@@ -34,8 +34,28 @@ module HTTPI
       # Accessor for the ca_path to validate SSL certificates.
       attr_accessor :ca_cert_path
 
-      # ertificate store holds trusted CA certificates used to verify peer certificates.
+      # Certificate store holds trusted CA certificates used to verify peer certificates.
       attr_accessor :cert_store
+
+      # Returns the available symmetric algorithms for encryption and decryption.
+      # @!attribute ciphers
+      #   @return [<String>, nil]
+      attr_reader :ciphers
+
+      # Sets the available symmetric algorithms for encryption and decryption.
+      # @see OpenSSL::SSL::SSLContext#ciphers
+      # @example
+      #   ssl.ciphers = "cipher1:cipher2:..."
+      #   ssl.ciphers = [name, ...]
+      #   ssl.ciphers = [[name, version, bits, alg_bits], ...]
+      def ciphers=(ciphers)
+        @ciphers =
+          if ciphers
+            context = OpenSSL::SSL::SSLContext.new
+            context.ciphers = ciphers
+            context.ciphers.map(&:first)
+          end
+      end
 
       # Returns the cert type to validate SSL certificates PEM|DER.
       def cert_type

--- a/spec/httpi/adapter/curb_spec.rb
+++ b/spec/httpi/adapter/curb_spec.rb
@@ -280,6 +280,7 @@ unless RUBY_PLATFORM =~ /java/
           request.auth.ssl.cert_key_file = "spec/fixtures/client_key.pem"
           request.auth.ssl.cert_file = "spec/fixtures/client_cert.pem"
           request.auth.ssl.cert_key_password = 'example'
+          request.auth.ssl.ciphers = OpenSSL::Cipher.ciphers
           request
         end
 

--- a/spec/httpi/adapter/excon_spec.rb
+++ b/spec/httpi/adapter/excon_spec.rb
@@ -93,6 +93,7 @@ describe HTTPI::Adapter::Excon do
       it "works when no client cert is specified" do
         request = HTTPI::Request.new(@server.url)
         request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
+        request.auth.ssl.ciphers = OpenSSL::Cipher.ciphers
 
         response = HTTPI.get(request, adapter)
         expect(response.body).to eq("get")
@@ -103,6 +104,7 @@ describe HTTPI::Adapter::Excon do
         request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
         request.auth.ssl.cert_file = "spec/fixtures/client_cert.pem"
         request.auth.ssl.cert_key_file = "spec/fixtures/client_key.pem"
+        request.auth.ssl.ciphers = OpenSSL::Cipher.ciphers
 
         response = HTTPI.get(request, adapter)
         expect(response.body).to eq("get")
@@ -114,6 +116,7 @@ describe HTTPI::Adapter::Excon do
         request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
         request.auth.ssl.cert = OpenSSL::X509::Certificate.new File.open("spec/fixtures/client_cert.pem").read
         request.auth.ssl.cert_key = OpenSSL::PKey.read File.open("spec/fixtures/client_key.pem").read
+        request.auth.ssl.ciphers = OpenSSL::Cipher.ciphers
 
         response = HTTPI.get(request, adapter)
         expect(response.body).to eq("get")

--- a/spec/httpi/adapter/http_spec.rb
+++ b/spec/httpi/adapter/http_spec.rb
@@ -91,6 +91,7 @@ describe HTTPI::Adapter::HTTP do
       it "works when set up properly" do
         request = HTTPI::Request.new(@server.url)
         request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
+        request.auth.ssl.ciphers = OpenSSL::Cipher.ciphers
 
         response = HTTPI.get(request, adapter)
         expect(response.body).to eq("get")

--- a/spec/httpi/adapter/httpclient_spec.rb
+++ b/spec/httpi/adapter/httpclient_spec.rb
@@ -133,12 +133,14 @@ describe HTTPI::Adapter::HTTPClient do
       before do
         request.auth.ssl.cert_key_file = "spec/fixtures/client_key.pem"
         request.auth.ssl.cert_file = "spec/fixtures/client_cert.pem"
+        request.auth.ssl.ciphers = OpenSSL::Cipher.ciphers
       end
 
       it "send certificate regardless of state of SSL verify mode" do
         request.auth.ssl.verify_mode = :none
         ssl_config.expects(:client_cert=).with(request.auth.ssl.cert)
         ssl_config.expects(:client_key=).with(request.auth.ssl.cert_key)
+        ssl_config.expects(:ciphers=).with(request.auth.ssl.ciphers)
 
         adapter.request(:get)
       end
@@ -147,6 +149,7 @@ describe HTTPI::Adapter::HTTPClient do
         ssl_config.expects(:client_cert=).with(request.auth.ssl.cert)
         ssl_config.expects(:client_key=).with(request.auth.ssl.cert_key)
         ssl_config.expects(:verify_mode=).with(request.auth.ssl.openssl_verify_mode)
+        ssl_config.expects(:ciphers=).with(request.auth.ssl.ciphers)
 
         adapter.request(:get)
       end
@@ -187,6 +190,14 @@ describe HTTPI::Adapter::HTTPClient do
     request = HTTPI::Request.new(@server.url + "ntlm-auth")
 
     request.auth.ntlm("tester", "vReqSoafRe5O")
+    response = HTTPI.get(request, :httpclient)
+    expect(response.body).to eq("ntlm-auth")
+  end
+
+  it "supports NTLM authentication with domain" do
+    request = HTTPI::Request.new(@server.url + "ntlm-auth")
+
+    request.auth.ntlm("tester", "vReqSoafRe5O", "domain")
     response = HTTPI.get(request, :httpclient)
     expect(response.body).to eq("ntlm-auth")
   end

--- a/spec/httpi/adapter/net_http_persistent_spec.rb
+++ b/spec/httpi/adapter/net_http_persistent_spec.rb
@@ -87,6 +87,10 @@ describe HTTPI::Adapter::NetHTTPPersistent do
         request = HTTPI::Request.new(@server.url)
         request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
 
+        if Gem::Version.new(Net::HTTP::Persistent::VERSION) >= Gem::Version.new('3.0.0')
+          request.auth.ssl.ciphers = OpenSSL::Cipher.ciphers
+        end
+
         response = HTTPI.get(request, adapter)
         expect(response.body).to eq("get")
       end

--- a/spec/httpi/auth/ssl_spec.rb
+++ b/spec/httpi/auth/ssl_spec.rb
@@ -158,6 +158,23 @@ describe HTTPI::Auth::SSL do
     end
   end
 
+  describe '#ciphers' do
+    subject { ssl.ciphers }
+    let(:ssl) { HTTPI::Auth::SSL.new }
+
+    context 'without ciphers' do
+      before { ssl.ciphers = nil }
+
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'with ciphers' do
+      before { ssl.ciphers = OpenSSL::Cipher.ciphers }
+
+      it { is_expected.to be_any.and(all(be_an_instance_of(String))) }
+    end
+  end
+
   def ssl
     ssl = HTTPI::Auth::SSL.new
     ssl.cert_key_file = "spec/fixtures/client_key.pem"


### PR DESCRIPTION
`http-net-persistent` only supports this configuration option since 3.0.0, earlier versions will fail with undefined method error, but only if you will use the option.
It also has `HTTP::Net::Persistent#initialize` signature changed, so I have to support both: old and new.
