### PR TITLE
Fix excon and http adapters

### DIFF
--- a/lib/httpi/adapter/excon.rb
+++ b/lib/httpi/adapter/excon.rb
@@ -77,7 +77,11 @@ module HTTPI
       end
 
       def respond_with(response)
-        Response.new response.status, response.headers, response.body
+        headers = response.headers.dup
+        if (cookies = response.data[:cookies]) && !cookies.empty?
+          headers["Set-Cookie"] = cookies
+        end
+        Response.new response.status, headers, response.body
       end
 
     end

--- a/lib/httpi/adapter/http.rb
+++ b/lib/httpi/adapter/http.rb
@@ -32,9 +32,13 @@ module HTTPI
         unless ::HTTP::Request::METHODS.include? method
           raise NotSupportedError, "http.rb does not support custom HTTP methods"
         end
-        response = @client.send(method, @request.url, :body => @request.body)
+        response = begin
+          @client.send(method, @request.url, :body => @request.body)
+        rescue OpenSSL::SSL::SSLError
+          raise SSLError
+        end
 
-        Response.new(response.code, response.headers, response.body.to_s)
+        Response.new(response.code, response.headers.to_h, response.body.to_s)
       end
 
       private

--- a/spec/integration/excon_spec.rb
+++ b/spec/integration/excon_spec.rb
@@ -1,0 +1,108 @@
+require "spec_helper"
+require "integration/support/server"
+
+describe HTTPI::Adapter::HTTPClient do
+
+  subject(:adapter) { :excon }
+
+  context "http requests" do
+    before :all do
+      @server = IntegrationServer.run
+    end
+
+    after :all do
+      @server.stop
+    end
+
+    it "sends and receives HTTP headers" do
+      request = HTTPI::Request.new(@server.url + "x-header")
+      request.headers["X-Header"] = "HTTPI"
+
+      response = HTTPI.get(request, adapter)
+      expect(response.body).to include("HTTPI")
+    end
+
+    it "it supports headers with multiple values" do
+      request = HTTPI::Request.new(@server.url + "cookies")
+
+      response = HTTPI.get(request, adapter)
+      cookies = ["cookie1=chip1; path=/", "cookie2=chip2; path=/"]
+      expect(response.headers["Set-Cookie"]).to eq(cookies)
+    end
+
+    it "executes GET requests" do
+      response = HTTPI.get(@server.url, adapter)
+      expect(response.body).to eq("get")
+      expect(response.headers["Content-Type"]).to eq("text/plain")
+    end
+
+    it "executes POST requests" do
+      response = HTTPI.post(@server.url, "<some>xml</some>", adapter)
+      expect(response.body).to eq("post")
+      expect(response.headers["Content-Type"]).to eq("text/plain")
+    end
+
+    it "executes HEAD requests" do
+      response = HTTPI.head(@server.url, adapter)
+      expect(response.code).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("text/plain")
+    end
+
+    it "executes PUT requests" do
+      response = HTTPI.put(@server.url, "<some>xml</some>", adapter)
+      expect(response.body).to eq("put")
+      expect(response.headers["Content-Type"]).to eq("text/plain")
+    end
+
+    it "executes DELETE requests" do
+      response = HTTPI.delete(@server.url, adapter)
+      expect(response.body).to eq("delete")
+      expect(response.headers["Content-Type"]).to eq("text/plain")
+    end
+
+    it "supports basic authentication" do
+      request = HTTPI::Request.new(@server.url + "basic-auth")
+      request.auth.basic("admin", "secret")
+
+      response = HTTPI.get(request, adapter)
+      expect(response.body).to eq("basic-auth")
+    end
+
+    it "supports chunked response" do
+      request = HTTPI::Request.new(@server.url)
+      res = ""
+      request.on_body do |body|
+        res += body
+      end
+      response = HTTPI.post(request, adapter)
+      expect(res).to eq("post")
+      expect(response.body).to eq("")
+    end
+  end
+
+  if RUBY_PLATFORM =~ /java/
+    pending "Puma Server complains: SSL not supported on JRuby"
+  else
+    context "https requests" do
+      before :all do
+        @server = IntegrationServer.run(:ssl => true)
+      end
+      after :all do
+        @server.stop
+      end
+
+      it "raises when no certificate was set up" do
+        expect { HTTPI.post(@server.url, "", adapter) }.to raise_error(HTTPI::SSLError)
+      end
+
+      it "works when set up properly" do
+        request = HTTPI::Request.new(@server.url)
+        request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
+
+        response = HTTPI.get(request, adapter)
+        expect(response.body).to eq("get")
+      end
+    end
+  end
+
+end

--- a/spec/integration/http_spec.rb
+++ b/spec/integration/http_spec.rb
@@ -1,0 +1,109 @@
+require "spec_helper"
+require "integration/support/server"
+
+describe HTTPI::Adapter::HTTP do
+
+  subject(:adapter) { :http }
+
+  context "http requests" do
+    before :all do
+      @server = IntegrationServer.run
+    end
+
+    after :all do
+      @server.stop
+    end
+
+    it "sends and receives HTTP headers" do
+      request = HTTPI::Request.new(@server.url + "x-header")
+      request.headers["X-Header"] = "HTTPI"
+
+      response = HTTPI.get(request, adapter)
+      expect(response.body).to include("HTTPI")
+    end
+
+    it "it supports headers with multiple values" do
+      request = HTTPI::Request.new(@server.url + "cookies")
+
+      response = HTTPI.get(request, adapter)
+      cookies = ["cookie1=chip1; path=/", "cookie2=chip2; path=/"]
+      expect(response.headers["Set-Cookie"]).to eq(cookies)
+    end
+
+    it "executes GET requests" do
+      response = HTTPI.get(@server.url, adapter)
+      expect(response.body).to eq("get")
+      expect(response.headers["Content-Type"]).to eq("text/plain")
+    end
+
+    it "executes POST requests" do
+      response = HTTPI.post(@server.url, "<some>xml</some>", adapter)
+      expect(response.body).to eq("post")
+      expect(response.headers["Content-Type"]).to eq("text/plain")
+    end
+
+    it "executes HEAD requests" do
+      response = HTTPI.head(@server.url, adapter)
+      expect(response.code).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("text/plain")
+    end
+
+    it "executes PUT requests" do
+      response = HTTPI.put(@server.url, "<some>xml</some>", adapter)
+      expect(response.body).to eq("put")
+      expect(response.headers["Content-Type"]).to eq("text/plain")
+    end
+
+    it "executes DELETE requests" do
+      response = HTTPI.delete(@server.url, adapter)
+      expect(response.body).to eq("delete")
+      expect(response.headers["Content-Type"]).to eq("text/plain")
+    end
+
+    it "supports basic authentication" do
+      request = HTTPI::Request.new(@server.url + "basic-auth")
+      request.auth.basic("admin", "secret")
+
+      response = HTTPI.get(request, adapter)
+      expect(response.body).to eq("basic-auth")
+    end
+
+    it "supports chunked response" do
+      skip("Needs investigation")
+      request = HTTPI::Request.new(@server.url)
+      res = ""
+      request.on_body do |body|
+        res += body
+      end
+      response = HTTPI.post(request, adapter)
+      expect(res).to eq("post")
+      expect(response.body).to eq("")
+    end
+  end
+
+  if RUBY_PLATFORM =~ /java/
+    pending "Puma Server complains: SSL not supported on JRuby"
+  else
+    context "https requests" do
+      before :all do
+        @server = IntegrationServer.run(:ssl => true)
+      end
+      after :all do
+        @server.stop
+      end
+
+      it "raises when no certificate was set up" do
+        expect { HTTPI.post(@server.url, "", adapter) }.to raise_error(HTTPI::SSLError)
+      end
+
+      it "works when set up properly" do
+        request = HTTPI::Request.new(@server.url)
+        request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
+
+        response = HTTPI.get(request, adapter)
+        expect(response.body).to eq("get")
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Hi, I noticed that `excon` and `http` adapters weren't read correctly cookies when they were set by multiple `Set-Cookie` headers. This PR fixes that.

I also added integration specs for `excon` and `http` adapters (just copied httpclient_spec), because they were missing. I needed to make additional changes to `http` adapter to make "https requests raises when no certificate was set up" spec pass.
I skipped "supports chunked response" spec - it is failing and I don't know what to do with it.