### PR TITLE
Don't convert port to string on Excon adapter

### DIFF
--- a/lib/httpi/adapter/excon.rb
+++ b/lib/httpi/adapter/excon.rb
@@ -42,7 +42,7 @@ module HTTPI
         opts = {
           :host => url.host,
           :path => url.path,
-          :port => url.port.to_s,
+          :port => url.port,
           :query => url.query,
           :scheme => url.scheme,
           :headers => @request.headers,


### PR DESCRIPTION
since excon internally checks for an integer (https://github.com/excon/excon/blob/master/lib/excon/utils.rb#L29)

Hey, folks! I'm running into an issue with Savon (thus HTTPI) and Excon. I need to seet "omit_default_port: true" or my request fails. omit_default_port depends on the port being 80 or 443, as integers [https://github.com/excon/excon/blob/master/lib/excon/utils.rb#L29]. Since httpi converts to string, the check is never true and the option is ignored.

Any reason in particular for converting to string? Any idea on how to catch this in the specs? :)