### PR TITLE
Rework of timeout errors (part 1): fix :http adapter support for read/open_timeout opts + add tests for these opts

### DIFF
--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -72,8 +72,8 @@ module HTTPI
       def basic_setup
         @client.url = @request.url.to_s
         @client.proxy_url = @request.proxy.to_s if @request.proxy
-        @client.timeout = @request.read_timeout if @request.read_timeout
-        @client.connect_timeout = @request.open_timeout if @request.open_timeout
+        @client.timeout_ms = @request.read_timeout * 1000 if @request.read_timeout
+        @client.connect_timeout_ms = @request.open_timeout * 1000 if @request.open_timeout
         @client.headers = @request.headers.to_hash
         @client.verbose = false
         # cURL workaround

--- a/lib/httpi/adapter/em_http.rb
+++ b/lib/httpi/adapter/em_http.rb
@@ -69,10 +69,10 @@ module HTTPI
       end
 
       def connection_options
-        options = {
-          :connect_timeout    => @request.open_timeout,
-          :inactivity_timeout => @request.read_timeout
-        }
+        options = {}
+
+        options[:inactivity_timeout] = @request.read_timeout if @request.read_timeout
+        options[:connect_timeout] = @request.open_timeout if @request.open_timeout
 
         options[:proxy] = proxy_options if @request.proxy
 

--- a/lib/httpi/adapter/http.rb
+++ b/lib/httpi/adapter/http.rb
@@ -73,6 +73,11 @@ module HTTPI
           client = client.via(@request.proxy.host, @request.proxy.port, @request.proxy.user, @request.proxy.password)
         end
 
+        timeouts = {}
+        timeouts[:connect] = @request.open_timeout if @request.open_timeout
+        timeouts[:read] = @request.read_timeout if @request.read_timeout
+        client = client.timeout(timeouts) if timeouts.any?
+
         client.headers(@request.headers)
       end
     end

--- a/spec/httpi/adapter/curb_spec.rb
+++ b/spec/httpi/adapter/curb_spec.rb
@@ -146,29 +146,29 @@ unless RUBY_PLATFORM =~ /java/
         end
       end
 
-      describe "timeout" do
+      describe "timeout_ms" do
         it "is not set unless it's specified" do
-          curb.expects(:timeout=).never
+          curb.expects(:timeout_ms=).never
           adapter.request(:get)
         end
 
         it "is set if specified" do
           request.read_timeout = 30
-          curb.expects(:timeout=).with(request.read_timeout)
+          curb.expects(:timeout_ms=).with(30_000)
 
           adapter.request(:get)
         end
       end
 
-      describe "connect_timeout" do
+      describe "connect_timeout_ms" do
         it "is not set unless it's specified" do
-          curb.expects(:connect_timeout=).never
+          curb.expects(:connect_timeout_ms=).never
           adapter.request(:get)
         end
 
         it "is set if specified" do
           request.open_timeout = 30
-          curb.expects(:connect_timeout=).with(30)
+          curb.expects(:connect_timeout_ms=).with(30_000)
 
           adapter.request(:get)
         end

--- a/spec/httpi/adapter/em_http_spec.rb
+++ b/spec/httpi/adapter/em_http_spec.rb
@@ -89,15 +89,12 @@ begin
         end
 
         it "sets host, port and authorization" do
-          url = 'http://example.com:80'
-
+          url = "http://example.com:80"
           connection_options = {
-            :connect_timeout    => nil,
-            :inactivity_timeout => nil,
-            :proxy              => {
-              :host          => 'proxy-host.com',
-              :port          => 443,
-              :authorization => ['username', 'password']
+            :proxy => {
+              :host => "proxy-host.com",
+              :port => 443,
+              :authorization => ["username", "password"]
             }
           }
 
@@ -111,8 +108,8 @@ begin
         it "is passed as a connection option" do
           request.open_timeout = 30
 
-          url = 'http://example.com:80'
-          connection_options = { :connect_timeout => 30, :inactivity_timeout => nil }
+          url = "http://example.com:80"
+          connection_options = { connect_timeout: 30 }
 
           EventMachine::HttpRequest.expects(:new).with(url, connection_options)
 
@@ -124,8 +121,8 @@ begin
         it "is passed as a connection option" do
           request.read_timeout = 60
 
-          url = 'http://example.com:80'
-          connection_options = { :connect_timeout => nil, :inactivity_timeout => 60 }
+          url = "http://example.com:80"
+          connection_options = { inactivity_timeout: 60 }
 
           EventMachine::HttpRequest.expects(:new).with(url, connection_options)
 

--- a/spec/integration/curb_spec.rb
+++ b/spec/integration/curb_spec.rb
@@ -40,7 +40,7 @@ describe HTTPI::Adapter::Curb do
         request.read_timeout = 0.5 # seconds
 
         expect do
-          puts HTTPI.get(request, adapter).inspect
+          HTTPI.get(request, adapter)
         end.to raise_exception(Curl::Err::TimeoutError)
       end
 

--- a/spec/integration/curb_spec.rb
+++ b/spec/integration/curb_spec.rb
@@ -33,6 +33,17 @@ describe HTTPI::Adapter::Curb do
         expect(response.headers["Set-Cookie"]).to eq(cookies)
       end
 
+      it "it supports read timeout" do
+        require "curb"
+
+        request = HTTPI::Request.new(@server.url + "timeout")
+        request.read_timeout = 0.5 # seconds
+
+        expect do
+          puts HTTPI.get(request, adapter).inspect
+        end.to raise_exception(Curl::Err::TimeoutError)
+      end
+
       it "executes GET requests" do
         response = HTTPI.get(@server.url, adapter)
         expect(response.body).to eq("get")

--- a/spec/integration/em_http_spec.rb
+++ b/spec/integration/em_http_spec.rb
@@ -42,6 +42,15 @@ describe HTTPI::Adapter::EmHttpRequest do
         expect(response.headers["Set-Cookie"]).to eq(cookies)
       end
 
+      it "it supports read timeout" do
+        request = HTTPI::Request.new(@server.url + "timeout")
+        request.read_timeout = 0.5 # seconds
+
+        expect do
+          puts HTTPI.get(request, adapter).inspect
+        end.to raise_exception(HTTPI::TimeoutError)
+      end
+
       it "executes GET requests" do
         response = HTTPI.get(@server.url, adapter)
         expect(response.body).to eq("get")

--- a/spec/integration/em_http_spec.rb
+++ b/spec/integration/em_http_spec.rb
@@ -47,7 +47,7 @@ describe HTTPI::Adapter::EmHttpRequest do
         request.read_timeout = 0.5 # seconds
 
         expect do
-          puts HTTPI.get(request, adapter).inspect
+          HTTPI.get(request, adapter)
         end.to raise_exception(HTTPI::TimeoutError)
       end
 

--- a/spec/integration/em_http_spec.rb
+++ b/spec/integration/em_http_spec.rb
@@ -42,13 +42,21 @@ describe HTTPI::Adapter::EmHttpRequest do
         expect(response.headers["Set-Cookie"]).to eq(cookies)
       end
 
-      it "it supports read timeout" do
-        request = HTTPI::Request.new(@server.url + "timeout")
-        request.read_timeout = 0.5 # seconds
+      if RUBY_PLATFORM =~ /java/
+        pending <<-MSG
+          It seems like JRuby is missing support for inactivity timeout! See related issues on GitHub:
+            - https://github.com/eventmachine/eventmachine/issues/155
+            - https://github.com/eventmachine/eventmachine/pull/312
+        MSG
+      else
+        it "it supports read timeout" do
+          request = HTTPI::Request.new(@server.url + "timeout")
+          request.read_timeout = 0.5 # seconds
 
-        expect do
-          HTTPI.get(request, adapter)
-        end.to raise_exception(HTTPI::TimeoutError)
+          expect do
+            HTTPI.get(request, adapter)
+          end.to raise_exception(HTTPI::TimeoutError)
+        end
       end
 
       it "executes GET requests" do

--- a/spec/integration/excon_spec.rb
+++ b/spec/integration/excon_spec.rb
@@ -30,6 +30,17 @@ describe HTTPI::Adapter::HTTPClient do
       expect(response.headers["Set-Cookie"]).to eq(cookies)
     end
 
+    it "it supports read timeout" do
+      require "excon"
+
+      request = HTTPI::Request.new(@server.url + "timeout")
+      request.read_timeout = 0.5 # seconds
+
+      expect do
+        HTTPI.get(request, adapter)
+      end.to raise_exception(Excon::Error::Timeout)
+    end
+
     it "executes GET requests" do
       response = HTTPI.get(@server.url, adapter)
       expect(response.body).to eq("get")

--- a/spec/integration/http_spec.rb
+++ b/spec/integration/http_spec.rb
@@ -30,6 +30,18 @@ describe HTTPI::Adapter::HTTP do
       expect(response.headers["Set-Cookie"]).to eq(cookies)
     end
 
+    it "it supports read timeout" do
+      require "http"
+
+      request = HTTPI::Request.new(@server.url + "timeout")
+      request.read_timeout = 0.5 # seconds
+
+      expect do
+        HTTPI.get(request, adapter)
+      end.to raise_exception(HTTP::TimeoutError)
+    end
+
+
     it "executes GET requests" do
       response = HTTPI.get(@server.url, adapter)
       expect(response.body).to eq("get")

--- a/spec/integration/httpclient_spec.rb
+++ b/spec/integration/httpclient_spec.rb
@@ -30,6 +30,17 @@ describe HTTPI::Adapter::HTTPClient do
       expect(response.headers["Set-Cookie"]).to eq(cookies)
     end
 
+    it "it supports read timeout" do
+      require "httpclient"
+
+      request = HTTPI::Request.new(@server.url + "timeout")
+      request.read_timeout = 0.5 # seconds
+
+      expect do
+        puts HTTPI.get(request, adapter).inspect
+      end.to raise_exception(HTTPClient::ReceiveTimeoutError)
+    end
+
     it "executes GET requests" do
       response = HTTPI.get(@server.url, adapter)
       expect(response.body).to eq("get")

--- a/spec/integration/httpclient_spec.rb
+++ b/spec/integration/httpclient_spec.rb
@@ -37,7 +37,7 @@ describe HTTPI::Adapter::HTTPClient do
       request.read_timeout = 0.5 # seconds
 
       expect do
-        puts HTTPI.get(request, adapter).inspect
+        HTTPI.get(request, adapter)
       end.to raise_exception(HTTPClient::ReceiveTimeoutError)
     end
 

--- a/spec/integration/net_http_persistent_spec.rb
+++ b/spec/integration/net_http_persistent_spec.rb
@@ -30,6 +30,17 @@ describe HTTPI::Adapter::NetHTTP do
       expect(response.headers["Set-Cookie"]).to eq(cookies)
     end
 
+    it "it supports read timeout" do
+      require "net/http/persistent"
+
+      request = HTTPI::Request.new(@server.url + "timeout")
+      request.read_timeout = 0.5 # seconds
+
+      expect do
+        HTTPI.get(request, adapter)
+      end.to raise_exception(Net::HTTP::Persistent::Error, /Net::ReadTimeout/)
+    end
+
     it "executes GET requests" do
       response = HTTPI.get(@server.url, adapter)
       expect(response.body).to eq("get")
@@ -38,7 +49,7 @@ describe HTTPI::Adapter::NetHTTP do
 
     it "executes POST requests" do
       request = HTTPI::Request.new(url: @server.url, open_timeout: 1, read_timeout: 1, body: "<some>xml</some>")
-      
+
       response = HTTPI.post(request, adapter)
       expect(response.body).to eq("post")
       expect(response.headers["Content-Type"]).to eq("text/plain")

--- a/spec/integration/net_http_spec.rb
+++ b/spec/integration/net_http_spec.rb
@@ -30,6 +30,15 @@ describe HTTPI::Adapter::NetHTTP do
       expect(response.headers["Set-Cookie"]).to eq(cookies)
     end
 
+    it "it supports read timeout" do
+      request = HTTPI::Request.new(@server.url + "timeout")
+      request.read_timeout = 0.5 # seconds
+
+      expect do
+        HTTPI.get(request, adapter)
+      end.to raise_exception(Net::ReadTimeout)
+    end
+
     it "executes GET requests" do
       response = HTTPI.get(@server.url, adapter)
       expect(response.body).to eq("get")

--- a/spec/integration/support/application.rb
+++ b/spec/integration/support/application.rb
@@ -15,9 +15,10 @@ class IntegrationServer
       }
     end
 
-    map "/repeat" do
+    map "/timeout" do
       run lambda { |env|
-        IntegrationServer.respond_with :body => env["rack.input"].read
+        sleep 2
+        IntegrationServer.respond_with "done"
       }
     end
 


### PR DESCRIPTION
Fix http adapter support for read/open_timeout + add tests for these options.

Source: https://github.com/savonrb/httpi/pull/195