### PR TITLE
Fix SSL protocols supported by curb adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tmp
 Gemfile.lock
 .idea/*
 .rbx/
+.ruby-version
+.ruby-gemset

--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -121,12 +121,14 @@ module HTTPI
         end
 
         @client.ssl_version = case ssl.ssl_version
-          when :TLSv1_2 then 1
-          when :TLSv1_1 then 1
-          when :TLSv1   then 1
-          when :SSLv2   then 2
-          when :SSLv23  then 2
-          when :SSLv3   then 3
+          when :TLSv1_2 then ::Curl::CURL_SSLVERSION_TLSv1_2
+          when :TLSv1_1 then ::Curl::CURL_SSLVERSION_TLSv1_1
+          when :TLSv1_0 then ::Curl::CURL_SSLVERSION_TLSv1_0
+          when :TLSv1   then ::Curl::CURL_SSLVERSION_TLSv1
+          when :SSLv2   then ::Curl::CURL_SSLVERSION_SSLv2
+          when :SSLv23  then ::Curl::CURL_SSLVERSION_SSLv2
+          when :SSLv3   then ::Curl::CURL_SSLVERSION_SSLv3
+          else ::Curl::CURL_SSLVERSION_DEFAULT
         end
       end
 

--- a/spec/httpi/adapter/curb_spec.rb
+++ b/spec/httpi/adapter/curb_spec.rb
@@ -251,15 +251,14 @@ unless RUBY_PLATFORM =~ /java/
         end
 
         context 'sets ssl_version' do
-          it 'defaults to nil when no ssl_version is specified' do
-            curb.expects(:ssl_version=).with(nil)
+          it 'defaults to 0 when no ssl_version is specified' do
+            curb.expects(:ssl_version=).with(0)
             adapter.request(:get)
           end
 
           it 'to 1 when ssl_version is specified as TLSv1' do
             request.auth.ssl.ssl_version = :TLSv1
             curb.expects(:ssl_version=).with(1)
-
             adapter.request(:get)
           end
 
@@ -267,14 +266,30 @@ unless RUBY_PLATFORM =~ /java/
             version = HTTPI::Auth::SSL::SSL_VERSIONS.select { |method| method.to_s.match(/SSLv2|SSLv23/) }.first
             request.auth.ssl.ssl_version = version
             curb.expects(:ssl_version=).with(2)
-
             adapter.request(:get)
           end
 
           it 'to 3 when ssl_version is specified as SSLv3' do
             request.auth.ssl.ssl_version = :SSLv3
             curb.expects(:ssl_version=).with(3)
+            adapter.request(:get)
+          end
 
+          it 'to 4 when ssl_version is specified as TLSv1_0' do
+            request.auth.ssl.ssl_version = :TLSv1_0
+            curb.expects(:ssl_version=).with(4)
+            adapter.request(:get)
+          end
+
+          it 'to 5 when ssl_version is specified as TLSv1_1' do
+            request.auth.ssl.ssl_version = :TLSv1_1
+            curb.expects(:ssl_version=).with(5)
+            adapter.request(:get)
+          end
+
+          it 'to 6 when ssl_version is specified as TLSv1_2' do
+            request.auth.ssl.ssl_version = :TLSv1_2
+            curb.expects(:ssl_version=).with(6)
             adapter.request(:get)
           end
         end


### PR DESCRIPTION
* Use Curl:: consts instead of *magic* numbers.
* Fix invalid values of TLSv1_1 and TLSv1_2 constants.
* Add support for TLSv1_0.