### PR TITLE
Set both :host, and :hostname options on excon connection to avoid warning.

### DIFF
--- a/lib/httpi/adapter/excon.rb
+++ b/lib/httpi/adapter/excon.rb
@@ -41,6 +41,7 @@ module HTTPI
 
         opts = {
           :host => url.host,
+          :hostname => url.hostname,
           :path => url.path,
           :port => url.port,
           :query => url.query,

--- a/spec/httpi/adapter/excon_spec.rb
+++ b/spec/httpi/adapter/excon_spec.rb
@@ -23,6 +23,12 @@ begin
           )
         end
       end
+      describe "host, hostname" do
+        it "both are set" do
+          Excon.expects(:display_warning).never
+          expect(adapter.client.data).to include(host: 'example.com', hostname: 'example.com')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
```
[excon][WARNING] hostname is missing! For IPv6 support, provide both host and hostname: Excon::Connection#new(:host => uri.host, :hostname => uri.hostname, ...).
```