### PR TITLE
Added support for net-http-persistent v3

### DIFF
--- a/lib/httpi/adapter/net_http_persistent.rb
+++ b/lib/httpi/adapter/net_http_persistent.rb
@@ -12,7 +12,11 @@ module HTTPI
       private
 
       def create_client
-        Net::HTTP::Persistent.new thread_key
+        if is_v3
+          Net::HTTP::Persistent.new name: thread_key
+        else
+          Net::HTTP::Persistent.new thread_key
+        end
       end
 
       def perform(http, http_request, &on_body)
@@ -37,6 +41,10 @@ module HTTPI
 
       def thread_key
         @request.url.host.split(/\W/).reject{|p|p == ""}.join('-')
+      end
+
+      def is_v3
+        Net::HTTP::Persistent::VERSION.start_with? "3."
       end
 
     end


### PR DESCRIPTION
The API for constructing new instances of `Net::HTTP::Persistent` changed slightly in net-http-persistent 3.x. This PR adds support for running both in v2 and v3.