### PR TITLE
Add SSL min/max_version configuration for supporting adapters

### DIFF
--- a/lib/httpi/adapter/curb.rb
+++ b/lib/httpi/adapter/curb.rb
@@ -128,6 +128,9 @@ module HTTPI
           when :SSLv23  then 2
           when :SSLv3   then 3
         end
+        if ssl.min_version || ssl.max_version
+          raise NotSupportedError, 'Curb adapter does not support #min_version or #max_version. Please, use #ssl_version instead.'
+        end
       end
 
       def respond_with(client)

--- a/lib/httpi/adapter/excon.rb
+++ b/lib/httpi/adapter/excon.rb
@@ -73,6 +73,8 @@ module HTTPI
         end
 
         opts[:ssl_version] = ssl.ssl_version if ssl.ssl_version
+        opts[:ssl_min_version] = ssl.min_version if ssl.min_version
+        opts[:ssl_max_version] = ssl.max_version if ssl.max_version
 
         opts
       end

--- a/lib/httpi/adapter/http.rb
+++ b/lib/httpi/adapter/http.rb
@@ -58,6 +58,8 @@ module HTTPI
           context.cert        = @request.auth.ssl.cert
           context.key         = @request.auth.ssl.cert_key
           context.ssl_version = @request.auth.ssl.ssl_version if @request.auth.ssl.ssl_version != nil
+          context.min_version = @request.auth.ssl.min_version if @request.auth.ssl.min_version != nil
+          context.max_version = @request.auth.ssl.max_version if @request.auth.ssl.max_version != nil
           context.verify_mode = @request.auth.ssl.openssl_verify_mode
 
           client = ::HTTP::Client.new(:ssl_context => context)

--- a/lib/httpi/adapter/httpclient.rb
+++ b/lib/httpi/adapter/httpclient.rb
@@ -78,6 +78,9 @@ module HTTPI
         end
 
         @client.ssl_config.ssl_version = ssl.ssl_version.to_s if ssl.ssl_version
+        if ssl.min_version || ssl.max_version
+          raise NotSupportedError, 'Httpclient adapter does not support #min_version or #max_version. Please, use #ssl_version instead'
+        end
       end
 
       def respond_with(response)

--- a/lib/httpi/adapter/net_http.rb
+++ b/lib/httpi/adapter/net_http.rb
@@ -182,6 +182,8 @@ module HTTPI
         end
 
         @client.ssl_version = ssl.ssl_version if ssl.ssl_version
+        @client.min_version = ssl.min_version if ssl.min_version
+        @client.max_version = ssl.max_version if ssl.max_version
       end
 
       def ssl_cert_store(ssl)

--- a/lib/httpi/auth/ssl.rb
+++ b/lib/httpi/auth/ssl.rb
@@ -20,6 +20,9 @@ module HTTPI
         ssl_context::METHODS.reject { |method| method.match(/server|client/) }
       end.sort.reverse
 
+      # Returns OpenSSL::SSL::*_VERSION values for min_version and max_version
+      MIN_MAX_VERSIONS = OpenSSL::SSL.constants.select{|constant| constant =~/_VERSION$/}.map{|version| version.to_s.gsub(/_VERSION$/,'').to_sym}.reverse
+
       # Returns whether SSL configuration is present.
       def present?
         (verify_mode == :none) || (cert && cert_key) || ca_cert_file
@@ -88,6 +91,36 @@ module HTTPI
         end
 
         @ssl_version = version
+      end
+
+      # Returns the SSL min_version number. Defaults to <tt>nil</tt> (auto-negotiate).
+      def min_version
+        @min_version ||= nil
+      end
+
+      # Sets the SSL min_version number. Expects one of <tt>HTTPI::Auth::SSL::MIN_MAX_VERSIONS</tt>.
+      def min_version=(version)
+        unless MIN_MAX_VERSIONS.include? version
+          raise ArgumentError, "Invalid SSL min_version #{version.inspect}\n" +
+                               "Please specify one of #{MIN_MAX_VERSIONS.inspect}"
+        end
+
+        @min_version = version
+      end
+
+      # Returns the SSL min_version number. Defaults to <tt>nil</tt> (auto-negotiate).
+      def max_version
+        @max_version ||= nil
+      end
+
+      # Sets the SSL min_version number. Expects one of <tt>HTTPI::Auth::SSL::MIN_MAX_VERSIONS</tt>.
+      def max_version=(version)
+        unless MIN_MAX_VERSIONS.include? version
+          raise ArgumentError, "Invalid SSL max_version #{version.inspect}\n" +
+                               "Please specify one of #{MIN_MAX_VERSIONS.inspect}"
+        end
+
+        @max_version = version
       end
 
       # Returns an <tt>OpenSSL::X509::Certificate</tt> for the +cert_file+.

--- a/spec/httpi/adapter/curb_spec.rb
+++ b/spec/httpi/adapter/curb_spec.rb
@@ -278,6 +278,16 @@ unless RUBY_PLATFORM =~ /java/
             adapter.request(:get)
           end
         end
+        it 'raises error when min_version not nil' do
+          request.auth.ssl.min_version = :TLS1_2
+          expect{ adapter.request(:get) }.
+            to raise_error(HTTPI::NotSupportedError, 'Curb adapter does not support #min_version or #max_version. Please, use #ssl_version instead.')
+        end
+        it 'raises error when max_version not nil' do
+          request.auth.ssl.max_version = :TLS1_2
+          expect{ adapter.request(:get) }.
+            to raise_error(HTTPI::NotSupportedError, 'Curb adapter does not support #min_version or #max_version. Please, use #ssl_version instead.')
+        end
       end
 
       context "(for SSL client auth)" do

--- a/spec/httpi/adapter/httpclient_spec.rb
+++ b/spec/httpi/adapter/httpclient_spec.rb
@@ -178,6 +178,17 @@ describe HTTPI::Adapter::HTTPClient do
 
         adapter.request(:get)
       end
+
+      it 'raises error when min_version not nil' do
+        request.auth.ssl.min_version = :TLS1_2
+        expect{ adapter.request(:get) }.
+          to raise_error(HTTPI::NotSupportedError, 'Httpclient adapter does not support #min_version or #max_version. Please, use #ssl_version instead')
+      end
+      it 'raises error when max_version not nil' do
+        request.auth.ssl.max_version = :TLS1_2
+        expect{ adapter.request(:get) }.
+          to raise_error(HTTPI::NotSupportedError, 'Httpclient adapter does not support #min_version or #max_version. Please, use #ssl_version instead')
+      end
     end
 
     context "(for SSL client auth with a verify mode of :none with no certs provided)" do

--- a/spec/httpi/auth/ssl_spec.rb
+++ b/spec/httpi/auth/ssl_spec.rb
@@ -4,6 +4,7 @@ require "httpi/auth/ssl"
 describe HTTPI::Auth::SSL do
   before(:all) do
     @ssl_versions = HTTPI::Auth::SSL::SSL_VERSIONS
+    @min_max_versions = HTTPI::Auth::SSL::MIN_MAX_VERSIONS
   end
 
   describe "VERIFY_MODES" do
@@ -155,6 +156,36 @@ describe HTTPI::Auth::SSL do
       expect { ssl.ssl_version = :ssl_fail }.
         to raise_error(ArgumentError, "Invalid SSL version :ssl_fail\n" +
                                       "Please specify one of #{@ssl_versions}")
+    end
+  end
+
+  describe "#min_version" do
+    subject { HTTPI::Auth::SSL.new }
+
+    it "returns the min_version" do
+      subject.min_version = @min_max_versions.first
+      expect(subject.min_version).to eq(@min_max_versions.first)
+    end
+
+    it 'raises ArgumentError if the version is unsupported' do
+      expect { ssl.min_version = :ssl_fail }.
+        to raise_error(ArgumentError, "Invalid SSL min_version :ssl_fail\n" +
+                                      "Please specify one of #{@min_max_versions}")
+    end
+  end
+
+  describe "#max_version" do
+    subject { HTTPI::Auth::SSL.new }
+
+    it "returns the SSL version" do
+      subject.max_version = @min_max_versions.first
+      expect(subject.max_version).to eq(@min_max_versions.first)
+    end
+
+    it 'raises ArgumentError if the version is unsupported' do
+      expect { ssl.max_version = :ssl_fail }.
+        to raise_error(ArgumentError, "Invalid SSL max_version :ssl_fail\n" +
+                                      "Please specify one of #{@min_max_versions}")
     end
   end
 

--- a/spec/integration/excon_spec.rb
+++ b/spec/integration/excon_spec.rb
@@ -129,6 +129,16 @@ describe HTTPI::Adapter::HTTPClient do
         expect(response.body).to eq("get")
       end
 
+      it "works with min_version/max_version" do
+        request = HTTPI::Request.new(@server.url)
+        request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
+        request.auth.ssl.min_version = :TLS1_2
+        request.auth.ssl.max_version = :TLS1_2
+
+        response = HTTPI.get(request, adapter)
+        expect(response.body).to eq("get")
+      end
+
       it "works with client cert and key provided as file path" do
         request = HTTPI::Request.new(@server.url)
         request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file

--- a/spec/integration/http_spec.rb
+++ b/spec/integration/http_spec.rb
@@ -131,6 +131,16 @@ describe HTTPI::Adapter::HTTP do
         response = HTTPI.get(request, adapter)
         expect(response.body).to eq("get")
       end
+
+      it "works with min_version/max_version" do
+        request = HTTPI::Request.new(@server.url)
+        request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
+        request.auth.ssl.min_version = :TLS1_2
+        request.auth.ssl.max_version = :TLS1_2
+
+        response = HTTPI.get(request, adapter)
+        expect(response.body).to eq("get")
+      end
     end
   end
 

--- a/spec/integration/net_http_spec.rb
+++ b/spec/integration/net_http_spec.rb
@@ -217,6 +217,16 @@ describe HTTPI::Adapter::NetHTTP do
         response = HTTPI.get(request, adapter)
         expect(response.body).to eq("get")
       end
+
+      it "works with min_version/max_version" do
+        request = HTTPI::Request.new(@server.url)
+        request.auth.ssl.ca_cert_file = IntegrationServer.ssl_ca_file
+        request.auth.ssl.min_version = :TLS1_2
+        request.auth.ssl.max_version = :TLS1_2
+
+        response = HTTPI.get(request, adapter)
+        expect(response.body).to eq("get")
+      end
     end
   end
 


### PR DESCRIPTION
`ssl_version` is deprecated and only provided for backwards compatibility. Documentation says to use `min_version=` and `max_version=` instead.

This PR adds support for these configuration options for the adapters that support them. `HTTPI::NotImplementedError` are raised for Curb and HttpClient that do not support these configuration options.

A new static `HTTPI::SSL::MIN_MAX_VERSIONS` is introduced to list the supported verions for min/max_verions. This is different than `HTTPI::SSL::SSL_VERSIONS` as the ssl_version value would be `TLSv1_2` where the min/max_version value is `TLS1_2`