### PR TITLE
Update travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: "ruby"
 script: "bundle exec rake ci"
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
   - 2.5.0
+  - 2.6.0
+  - 2.7.0
   - jruby-9.1.9.0
 env:
   global:


### PR DESCRIPTION
Drop Travis CI support for Ruby < 2.3.0 support. Ruby 2.3.0 and prior is end of life and no longer supported as of March 31, 2019
Add Ruby 2.6.0 and 2.7.0 to Travis CI

Additionally, there are gems which do not support < 2.4.0 like simplecov-html used in the ci/test process.

I am not able to install jruby on this machine so I did not touch anything relating to it.
