### PR TITLE
CI: Slim down configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: "ruby"
 script: "bundle exec rake ci"
 rvm:
-  - 2.5.0
-  - 2.6.0
-  - 2.7.0
-  - jruby-9.2.12.0
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
 language: "ruby"
 script: "bundle exec rake ci"
-sudo: false
 rvm:
   - 2.5.0
   - 2.6.0
   - 2.7.0
-  - jruby-9.1.9.0
-env:
-  global:
-    - JRUBY_OPTS="--2.0"
-before_install:
-  - "travis_retry gem install bundler"
+  - jruby-9.2.12.0


### PR DESCRIPTION

- Drop unused `sudo: false` Travis directive  See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
- Expect Bundler to be installed with each supported Ruby
- Update the CI matrix to use latest JRuby, **9.2.12.0**. [JRuby 9.2.12.0 release blog post](https://www.jruby.org/2020/07/01/jruby-9-2-12-0.html)
- Use latest Ruby patch versions