### PR TITLE
gemspec: Drop rubyforge reference

### DIFF
--- a/httpi.gemspec
+++ b/httpi.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.required_ruby_version = '>= 1.9.2'
 
-  s.rubyforge_project = s.name
   s.license = 'MIT'
 
   s.add_dependency 'rack'


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* rubygems/rubygems#2436 deprecated the `rubyforge_project` property (ah well, they're undeprecated now, but still _quite_ unused)

[1]: https://twitter.com/evanphx/status/399552820380053505

---

The warning looks like:

```
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /Users/olle/opensource/httpi/httpi.gemspec:16.
```