### PR TITLE
Upgrade to coveralls_reborn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,4 @@ gem 'http',                             :require => false
 
 # coverage
 gem 'simplecov',                        :require => false
-gem 'coveralls',                        :require => false
+gem 'coveralls_reborn',                 :require => false


### PR DESCRIPTION
The Travis build exhibit the issue reported here: https://github.com/lemurheavy/coveralls-ruby/issues/161

It seems that the coveralls project [is abandoned](https://github.com/lemurheavy/coveralls-ruby/issues/130).  There is a fork, coveralls_reborn, which is actively maintained https://github.com/lemurheavy/coveralls-ruby.

Disclaimer: I don't have any knowledge or opinion about the merits of coveralls_reborn apart from what I have red via the links above.