### PR TITLE
CI: Add Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: "ruby"
 script: "bundle exec rake ci"
 rvm:
-  - 2.5.8
-  - 2.6.6
-  - 2.7.1
+  - "2.5"
+  - "2.6"
+  - "2.7"
+  - "3.0"


### PR DESCRIPTION
By pointing out only the minor version, RVM has the responsibility for updating the defintion of what those mean. Less activity for this project.