### PR TITLE
CI: Use latest patch versions of Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: "ruby"
 script: "bundle exec rake ci"
 rvm:
-  - 2.5.8
-  - 2.6.6
-  - 2.7.1
+  - 2.5.9
+  - 2.6.7
+  - 2.7.3


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known