### PR TITLE
CI: Use GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ jobs:
           - jruby
 
     steps:
+      - name: Install cURL Headers
+        run: curl https://curl.se/download/curl-$V.tar.gz | sudo tar xz -C /usr --strip-components=1 curl-$V/include
+        env:
+          V: 7.58.0
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Install cURL Headers
-        run: sudo apt-get update && sudo apt install libcurl-dev
+        run: sudo apt-get update && sudo apt install libcurl4-openssl-dev
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version:
+          - "3.0" # Quoted, to avoid float-to-string becoming "3"
+          - 2.7
+          - 2.6
+          - 2.5
+          - jruby
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec rake ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
       - name: Install cURL Headers
-        run: curl https://curl.se/download/curl-$V.tar.gz | sudo tar xz -C /usr --strip-components=1 curl-$V/include
-        env:
-          V: 7.58.0
+        run: sudo apt-get update && sudo apt install libcurl-dev
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
           - 2.7
           - 2.6
           - 2.5
-          - jruby
 
     steps:
       - name: Install cURL Headers


### PR DESCRIPTION
Fixes #222

- [x] add CI YAML
- [x] add libcurl
- [ ] add ruby headers

## TODO: Current problem

Ruby's header files are needed to install  `http_parser` ext. These files are not available to this PR.