### PR TITLE
Use HTTPS for "homepage" in gemspec [ci skip]

### DIFF
--- a/httpi.gemspec
+++ b/httpi.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version     = HTTPI::VERSION
   s.authors     = ['Daniel Harrington', 'Martin Tepper']
   s.email       = 'me@rubiii.com'
-  s.homepage    = "http://github.com/savonrb/#{s.name}"
+  s.homepage    = "https://github.com/savonrb/httpi"
   s.summary     = "Common interface for Ruby's HTTP libraries"
   s.description = s.summary
 


### PR DESCRIPTION
Also, use a literal string without interpolations, for legibility.