### PR TITLE
pin rack < 3 for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'net-http-persistent', '~> 4.0',    :require => false
 gem 'http',                             :require => false
 
 # adapter extensions
-gem 'rack'
+gem 'rack', '< 3'
 gem 'socksify'
 
 # coverage

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'httpclient',          '~> 2.3',    :require => false
 gem 'curb',                '~> 0.8',    :require => false, :platforms => [:ruby]
 gem 'em-http-request',                  :require => false, :platforms => [:ruby]
 gem 'em-synchrony',                     :require => false, :platforms => [:ruby, :jruby]
-gem 'excon',               '~> 0.21',   :require => false, :platforms => [:ruby, :jruby]
+gem 'excon',               '~> 0.71',   :require => false, :platforms => [:ruby, :jruby]
 gem 'net-http-persistent', '~> 4.0',    :require => false
 gem 'http',                             :require => false
 

--- a/httpi.gemspec
+++ b/httpi.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency 'rack'
+  s.add_dependency 'rack', '< 3'
 
   s.add_development_dependency 'rubyntlm', '~> 0.3.2'
   s.add_development_dependency 'rake',     '~> 13.0'


### PR DESCRIPTION
Ref: #236

Rack 3.0 was released recently and has a number of breaking changes and deprecations. We should lock to the prior version until we have explicitly validated support for all the breaking changes.

https://github.com/rack/rack/blob/main/CHANGELOG.md#300beta1---2022-08-08

Locally I get 10 rspec failures if I naively upgrade to rack 3 and run `bundle exec rspec`:
![image](https://user-images.githubusercontent.com/222655/191604649-d4214a92-740d-4607-8e76-2dbb60a423a7.png)
