### PR TITLE
re-enable ntlm tests

### DIFF
--- a/httpi.gemspec
+++ b/httpi.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'base64'
   s.add_dependency 'mutex_m'
 
-  s.add_development_dependency 'rubyntlm', '~> 0.3.2'
+  s.add_development_dependency 'rubyntlm', '~> 0.6.4'
   s.add_development_dependency 'rake',     '~> 13.0'
   s.add_development_dependency 'rspec',    '~> 3.5'
   s.add_development_dependency 'mocha',    '~> 0.13'

--- a/spec/httpi/adapter/httpclient_spec.rb
+++ b/spec/httpi/adapter/httpclient_spec.rb
@@ -215,8 +215,7 @@ describe HTTPI::Adapter::HTTPClient do
     end
   end
 
-  # TODO: ntlm_openssl3 https://github.com/WinRb/rubyntlm/issues/57
-  xit "supports NTLM authentication" do
+  it "supports NTLM authentication" do
     request = HTTPI::Request.new(@server.url + "ntlm-auth")
 
     request.auth.ntlm("tester", "vReqSoafRe5O")

--- a/spec/integration/net_http_spec.rb
+++ b/spec/integration/net_http_spec.rb
@@ -138,8 +138,7 @@ describe HTTPI::Adapter::NetHTTP do
         to raise_error(HTTPI::NotSupportedError, /does not support HTTP digest authentication/)
     end
 
-    # TODO: ntlm_openssl3 https://github.com/WinRb/rubyntlm/issues/57
-    xit "supports ntlm authentication" do
+    it "supports ntlm authentication" do
       request = HTTPI::Request.new(@server.url + "ntlm-auth")
       request.auth.ntlm("tester", "vReqSoafRe5O")
 
@@ -167,8 +166,7 @@ describe HTTPI::Adapter::NetHTTP do
       HTTPI::Adapter::NetHTTP.any_instance.unstub(:check_net_ntlm_version!)
     end
 
-    # TODO: ntlm_openssl3 https://github.com/WinRb/rubyntlm/issues/57
-    xit "does check ntlm when ntlm authentication is requested" do
+    it "does check ntlm when ntlm authentication is requested" do
       request = HTTPI::Request.new(@server.url + "ntlm-auth")
       request.auth.ntlm("tester", "vReqSoafRe5O")
 
@@ -185,8 +183,7 @@ describe HTTPI::Adapter::NetHTTP do
       HTTPI::Adapter::NetHTTP.any_instance.unstub(:ntlm_version)
     end
 
-    # TODO: ntlm_openssl3 https://github.com/WinRb/rubyntlm/issues/57
-    xit "does not crash when authenticate header is missing (on second request)" do
+    it "does not crash when authenticate header is missing (on second request)" do
       request = HTTPI::Request.new(@server.url + "ntlm-auth")
       request.auth.ntlm("tester", "vReqSoafRe5O")
 


### PR DESCRIPTION
latest ntlm release addresses openssl3 issues. re-enabling the tests and bumping the ntlm version used in specs. fixes https://github.com/savonrb/httpi/issues/243