### PR TITLE
use rack 2.2x headers implementation

### DIFF
--- a/spec/httpi/response_spec.rb
+++ b/spec/httpi/response_spec.rb
@@ -118,6 +118,10 @@ describe HTTPI::Response do
       it "returns the HTTP response headers" do
         expect(response.headers).to eq HTTPI::Utils::Headers.new.merge({ "Content-Type" => "application/dime" })
       end
+
+      it "preserves casing" do
+        expect(response.headers.keys).to eq ["Content-Type"]
+      end
     end
 
     describe "#body" do


### PR DESCRIPTION
Resolves #248 

This should have roughly the effect of reverting to an older (more compatible) rack http header hash behavior, even though the public API since v4 is no longer provided by rack itself.

Context: https://github.com/savonrb/httpi/pull/245
