### PR TITLE
CI: Get to green on Ruby head (4.1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,14 @@ gem 'public_suffix', '~> 4.0'
 # http clients
 gem 'httpclient',          '~> 2.3',    :require => false
 # curb 1.0 moved to the TypedData API; the 0.x line no longer compiles on
-# Ruby 4.1, which removed the untyped Data_Get_Struct.
-gem 'curb',                '~> 1.3',    :require => false, :platforms => [:ruby]
+# Ruby 4.1, which removed the untyped Data_Get_Struct. TruffleRuby, however,
+# crashes its reference-processor thread on curb 1.x's TypedData finalizers
+# ("dead handle" in rb_tr_rtypeddata_run_finalizer), so keep 0.x there.
+if RUBY_ENGINE == 'truffleruby'
+  gem 'curb',              '~> 0.9',    :require => false
+else
+  gem 'curb',              '~> 1.3',    :require => false, :platforms => [:ruby]
+end
 # eventmachine (em-http-request's transitive dependency) still uses the untyped
 # Data_Wrap_Struct API, which Ruby 4.1 removed, and 1.2.7 is the last release.
 # Skip the em adapter's dependencies there so bundle install keeps working.

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,16 @@ gem 'public_suffix', '~> 4.0'
 
 # http clients
 gem 'httpclient',          '~> 2.3',    :require => false
-gem 'curb',                '~> 0.8',    :require => false, :platforms => [:ruby]
-gem 'em-http-request',                  :require => false, :platforms => [:ruby]
-gem 'em-synchrony',                     :require => false, :platforms => [:ruby, :jruby]
+# curb 1.0 moved to the TypedData API; the 0.x line no longer compiles on
+# Ruby 4.1, which removed the untyped Data_Get_Struct.
+gem 'curb',                '~> 1.3',    :require => false, :platforms => [:ruby]
+# eventmachine (em-http-request's transitive dependency) still uses the untyped
+# Data_Wrap_Struct API, which Ruby 4.1 removed, and 1.2.7 is the last release.
+# Skip the em adapter's dependencies there so bundle install keeps working.
+if RUBY_VERSION < '4.1'
+  gem 'em-http-request',                :require => false, :platforms => [:ruby]
+  gem 'em-synchrony',                   :require => false, :platforms => [:ruby, :jruby]
+end
 # excon >= 1.5.0 fixes CVE-2026-54171 but requires Ruby >= 3.1.
 # On Ruby 3.0 fall back to the old line. The audit job runs on 3.4,
 # so it resolves the patched excon.

--- a/spec/httpi/adapter/em_http_spec.rb
+++ b/spec/httpi/adapter/em_http_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "httpi/adapter/em_http"
 require "httpi/request"
 
-unless RUBY_PLATFORM =~ /java/
+if EM_HTTP_AVAILABLE
   HTTPI::Adapter.load_adapter(:em_http)
 
   describe HTTPI::Adapter::EmHttpRequest do

--- a/spec/httpi/httpi_spec.rb
+++ b/spec/httpi/httpi_spec.rb
@@ -7,8 +7,6 @@ require "net/http/persistent"
 require "http"
 
 unless RUBY_PLATFORM =~ /java/
-  require "em-synchrony"
-  require "em-http-request"
   require "curb"
 end
 
@@ -316,7 +314,10 @@ describe HTTPI do
       end
 
       HTTPI::Adapter::ADAPTERS.each do |adapter, opts|
-        unless (adapter == :em_http || adapter == :curb) && RUBY_PLATFORM =~ /java/
+        skip_adapter = (adapter == :curb && RUBY_PLATFORM =~ /java/) ||
+          (adapter == :em_http && !EM_HTTP_AVAILABLE)
+
+        unless skip_adapter
           client_class = {
             :httpclient => lambda { HTTPClient },
             :curb       => lambda { Curl::Easy },

--- a/spec/integration/em_http_spec.rb
+++ b/spec/integration/em_http_spec.rb
@@ -3,10 +3,7 @@ require "integration/support/server"
 
 describe HTTPI::Adapter::EmHttpRequest do
 
-  # em_http is not supported on java
-  unless RUBY_PLATFORM =~ /java/
-    require "em-synchrony"
-
+  if EM_HTTP_AVAILABLE
     subject(:adapter) { :em_http }
 
     around :each do |example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,18 @@ end
 require 'httpi'
 require 'rspec'
 
+# The em_http adapter needs eventmachine, which has no JRuby-compatible C
+# extension and does not build on Ruby >= 4.1 (1.2.7, its last release, still
+# uses the untyped Data API that Ruby removed). The Gemfile omits the gems
+# there, so detect them instead of assuming they are installed.
+EM_HTTP_AVAILABLE = RUBY_PLATFORM !~ /java/ && begin
+  require "em-synchrony"
+  require "em-http-request"
+  true
+rescue LoadError
+  false
+end
+
 RSpec.configure do |config|
   config.mock_with :mocha
   config.order = 'random'


### PR DESCRIPTION
Slop:

Ruby head is now 4.1. It removed the untyped `Data_Wrap_Struct`/`Data_Get_Struct` C API.

In order to keep us buildable:

- curb: TruffleRuby stays on < 1.0 of curb (that builds)
- curb: Ruby 4.1 uses 1.0+ (that bilds)
- em-http-request/em-synchrony: only declared Ruby <4.1. (eventmachine 1.2.7 is its last release (2018), so there is no version to bump to.)

See: https://github.com/savonrb/httpi/actions/runs/30506928846/job/90758618681